### PR TITLE
fix(data): repair loading of existing data on the CLI and in the REPL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,12 @@ jobs:
   engine:
     name: Engine+contract (Julia ${{ matrix.version }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # 30 min stopped fitting: the surface reached 303 leaves and MEMs 0.7.0 made
+    # JuMP+Ipopt required deps (C060), so a cold-cache run precompiles a heavy tree
+    # before a single test runs. ubuntu-1.12 and windows hit exactly 30m00 while
+    # macOS finished in 23m38 and ubuntu-Julia-1 in 28m30 — every leg was at the
+    # edge and two tipped over. Budget for the slow legs, not the fastest one.
+    timeout-minutes: 60
     permissions:
       actions: write
       contents: read
@@ -81,7 +86,9 @@ jobs:
   integration-core:
     name: Integration core (T3)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # T3 grew 1280 -> 1498 cases as #85 closed the predict/residuals/nowcast/data
+    # coverage gaps; 13m53 on one PR and 15m17 (timeout) on the next. Same story.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
@@ -104,7 +111,8 @@ jobs:
   e2e:
     name: E2E subprocess (T4)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Each E2E case pays a fresh process start; 12m19 vs a 15m budget, then 15m18.
+    timeout-minutes: 40
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/README.md
+++ b/README.md
@@ -571,9 +571,15 @@ friedman filter x13 monthly.csv --frequency=12 --method=x11
 # List available example datasets
 friedman data list
 
-# Load example dataset (FRED-MD, FRED-QD, PWT, mpdta, ddcg)
+# Load an example dataset (see `data list` for all 11)
 friedman data load fred_md --output=fred_md.csv
 friedman data load fred_md --vars=INDPRO,CPIAUCSL --transform
+
+# Load your own CSV (no dataset name needed)
+friedman data load --path=mydata.csv --output=loaded.csv
+
+# Any <data> argument also accepts a `:name` reference to a bundled dataset
+friedman data describe :fred_md
 
 # Describe data (summary statistics)
 friedman data describe data.csv

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -61,6 +61,12 @@ makedocs(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://friedmanjp.github.io/Friedman-cli",
         edit_link = "master",
+        # The generated CLI reference is one page per top-level command, and the
+        # biggest (estimate: 66 leaves, test: 65) render well past Documenter's
+        # 200 KiB default. These are lookup tables an agent greps, not prose —
+        # raise the ceiling instead of fragmenting the reference across pages.
+        size_threshold = 500 * 2^10,
+        size_threshold_warn = 300 * 2^10,
     ),
     # docs_block: internal API surface is large; missing @docs bindings must not fail CI
     warnonly = [:missing_docs, :docs_block],

--- a/docs/src/commands/data.md
+++ b/docs/src/commands/data.md
@@ -23,7 +23,29 @@ friedman data list
 | `fred_qd` | Time Series | 268 x 245 | FRED-QD Quarterly Database (245 macroeconomic indicators) |
 | `pwt` | Panel | 38 x 74 x 42 | Penn World Table (38 OECD countries, 74 years, 42 variables) |
 | `mpdta` | Panel | 500 x 5 x 3 | Callaway-Sant'Anna (2021) minimum wage panel |
-| `ddcg` | Panel | 184 x 51 | Acemoglu et al. democracy-GDP panel |
+| `ddcg` | Panel | 184 x 51 x 2 | Acemoglu et al. democracy-GDP panel |
+| `denmark` | Time Series | 55 x 5 | Danish money-demand data (Johansen-Juselius cointegration) |
+| `gnp_hamilton` | Time Series | 135 x 1 | US GNP growth (Hamilton 1989 Markov-switching example) |
+| `grunfeld` | Panel | 10 x 20 x 3 | Grunfeld investment panel (10 firms, 20 years) |
+| `mroz` | Cross Section | 753 x 22 | Mroz (1987) female labour supply |
+| `nile` | Time Series | 100 x 1 | Nile river annual flow (local-level state space) |
+| `stackloss` | Cross Section | 21 x 4 | Brownlee stack-loss plant data (robust regression) |
+
+The `wiot` input-output table is not listed here: it is an IO archive served by the
+[`io`](io.md) family rather than a rectangular dataset.
+
+### Referring to a dataset
+
+Every command that takes a `<data>` path also accepts a `:name` reference to a bundled
+dataset, and both separator spellings resolve to the same set:
+
+```bash
+friedman data describe :fred_md      # equivalently :fred-md, fred_md, fred-md
+friedman test cips :grunfeld --id-col=group --time-col=time
+```
+
+Panel datasets expose their identifiers as leading `group` and `time` columns, so panel
+commands can bind `--id-col`/`--time-col` directly to a bundled panel.
 
 ## data load
 
@@ -34,14 +56,18 @@ Load an example dataset or CSV file and export.
 friedman data load fred_md --output=macro.csv
 friedman data load fred_md --vars=INDPRO,UNRATE,CPIAUCSL --transform
 friedman data load pwt --country=USA --output=us_data.csv
+friedman data load :fred-md --output=macro.csv     # ':' reference also accepted
 
-# From CSV file with date labels
-friedman data load mydata --path=data.csv --dates=date_column
+# From a CSV file — no dataset name needed
+friedman data load --path=data.csv --dates=date_column
 ```
+
+Give either a dataset `<name>` or `--path`; supplying neither is a usage error. When both
+are given, `--path` wins and a note is written to stderr.
 
 | Argument | Description |
 |----------|-------------|
-| `<name>` | Dataset name (`fred_md`, `fred_qd`, `pwt`, `mpdta`, `ddcg`) or label for `--path` |
+| `<name>` | Example dataset name (optional; see `data list`). Omit when using `--path` |
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|

--- a/docs/src/commands/generated/data.md
+++ b/docs/src/commands/generated/data.md
@@ -151,11 +151,11 @@ table|csv|json
 
 ### `friedman data load`
 
-Dataset name (fred_md|fred_qd|pwt|mpdta|ddcg) or empty for --path
+Example dataset name (see 'data list'), or omit and pass --path for a CSV
 
 | Argument | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `name` | `String` | yes | — |  |
+| `name` | `String` | no | `""` | Example dataset name |
 
 | Option | Short | Type | Default | Choices | Description |
 |--------|-------|------|---------|---------|-------------|
@@ -166,7 +166,11 @@ Dataset name (fred_md|fred_qd|pwt|mpdta|ddcg) or empty for --path
 | `--dates` | — | `String` | `""` | — | Column name for date labels |
 | `--path` | — | `String` | `""` | — | Path to CSV file (alternative to named dataset) |
 
-**Output tables:** `data_load` (Dataset name (fred_md|fred_qd|pwt|mpdta|ddcg) or empty for --path)
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--transform` | `-t` | Apply FRED transformation codes |
+
+**Output tables:** `data_load` (Example dataset name (see 'data list'), or omit and pass --path for a CSV)
 
 ---
 

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -79,7 +79,7 @@ friedman> estimate var --la<Tab>  -> --lags
 
 | Command | Description |
 |---------|-------------|
-| `data use <path>` | Load CSV file into session (`~` is expanded) |
+| `data use <path>` | Load CSV file into session (`~` is expanded on every platform, Windows included) |
 | `data use :<name>` | Load a bundled dataset -- any name from `data list`, with either separator (`:fred-md` or `:fred_md`) |
 | `data current` | Show current dataset and cached results |
 | `data clear` | Clear data and all cached results |

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -79,8 +79,8 @@ friedman> estimate var --la<Tab>  -> --lags
 
 | Command | Description |
 |---------|-------------|
-| `data use <path>` | Load CSV file into session |
-| `data use :<name>` | Load built-in dataset (`:fred-md`, `:fred-qd`, `:pwt`, `:mpdta`, `:ddcg`) |
+| `data use <path>` | Load CSV file into session (`~` is expanded) |
+| `data use :<name>` | Load a bundled dataset -- any name from `data list`, with either separator (`:fred-md` or `:fred_md`) |
 | `data current` | Show current dataset and cached results |
 | `data clear` | Clear data and all cached results |
 | `exit` / `quit` | Leave the REPL (also Ctrl-D) |

--- a/src/commands/data.jl
+++ b/src/commands/data.jl
@@ -233,7 +233,7 @@ function _data_load(; name::String="", output::String="", format::String="table"
     # If --path is given, load from CSV instead of example datasets
     if !isempty(path)
         isempty(name) || _status("Both <name> and --path given; loading --path $path")
-        path = expanduser(path)
+        path = _expanduser(path)
         df = load_data(path)
         Y = df_to_matrix(df)
         vn = variable_names(df)

--- a/src/commands/data.jl
+++ b/src/commands/data.jl
@@ -33,8 +33,8 @@ function data_specs()::Vector{CommandSpec}
         ),
         CommandSpec(
             path=["data", "load"],
-            summary="Dataset name (fred_md|fred_qd|pwt|mpdta|ddcg) or empty for --path",
-            args=[ArgSpec(name="name", type=String, required=true, default=nothing, description="")],
+            summary="Example dataset name (see 'data list'), or omit and pass --path for a CSV",
+            args=[ArgSpec(name="name", type=String, required=false, default="", description="Example dataset name")],
             options=[
                 OptionSpec(name="output", short="o", type=String, default="", description="Output CSV file path"),
                 OptionSpec(name="format", short="f", type=String, default="table", description="table|csv|json", choices=["table","csv","json"]),
@@ -43,8 +43,8 @@ function data_specs()::Vector{CommandSpec}
                 OptionSpec(name="dates", type=String, default="", description="Column name for date labels"),
                 OptionSpec(name="path", type=String, default="", description="Path to CSV file (alternative to named dataset)")
             ],
-            flags=FlagSpec[],
-            tables=[TableSpec(name=:data_load, description="Dataset name (fred_md|fred_qd|pwt|mpdta|ddcg) or empty for --path")],
+            flags=[FlagSpec(name="transform", short="t", description="Apply FRED transformation codes")],
+            tables=[TableSpec(name=:data_load, description="Example dataset name (see 'data list'), or omit and pass --path for a CSV")],
             category="data",
             handler=wrap_legacy(_data_load),
         ),
@@ -191,30 +191,49 @@ end
 
 # ── Handlers ─────────────────────────────────────────────
 
+# Descriptions for the bundled example datasets, keyed by their MEMs symbol.
+# The table is built by walking EXAMPLE_DATASETS, so this map cannot silently
+# omit a dataset that `data load` accepts.
+const _DATASET_INFO = Dict(
+    :fred_md      => ("Time Series",  "804 × 126",    "FRED-MD Monthly Database (126 macroeconomic indicators)"),
+    :fred_qd      => ("Time Series",  "268 × 245",    "FRED-QD Quarterly Database (245 macroeconomic indicators)"),
+    :pwt          => ("Panel",        "38 × 74 × 42", "Penn World Table (38 OECD countries, 74 years, 42 variables)"),
+    :mpdta        => ("Panel",        "500 × 5 × 3",  "Callaway-Sant'Anna (2021) minimum wage panel"),
+    :ddcg         => ("Panel",        "184 × 51 × 2", "Acemoglu et al. democracy-GDP panel"),
+    :denmark      => ("Time Series",  "55 × 5",       "Danish money-demand data (Johansen-Juselius cointegration)"),
+    :gnp_hamilton => ("Time Series",  "135 × 1",      "US GNP growth (Hamilton 1989 Markov-switching example)"),
+    :grunfeld     => ("Panel",        "10 × 20 × 3",  "Grunfeld investment panel (10 firms, 20 years)"),
+    :mroz         => ("Cross Section", "753 × 22",    "Mroz (1987) female labour supply"),
+    :nile         => ("Time Series",  "100 × 1",      "Nile river annual flow (local-level state space)"),
+    :stackloss    => ("Cross Section", "21 × 4",      "Brownlee stack-loss plant data (robust regression)"),
+)
+
 function _data_list(; format::String="table", output::String="")
-    datasets = [
-        ("fred_md",  "Time Series", "804 × 126",    "FRED-MD Monthly Database (126 macroeconomic indicators)"),
-        ("fred_qd",  "Time Series", "268 × 245",    "FRED-QD Quarterly Database (245 macroeconomic indicators)"),
-        ("pwt",      "Panel",       "38 × 74 × 42", "Penn World Table (38 OECD countries, 74 years, 42 variables)"),
-        ("mpdta",    "Panel",       "500 × 5 × 3",  "Callaway-Sant'Anna (2021) minimum wage panel"),
-        ("ddcg",     "Panel",       "184 × 51",     "Acemoglu et al. democracy-GDP panel"),
-    ]
+    info(d) = get(_DATASET_INFO, d, ("", "", ""))
 
     df = DataFrame(
-        name=String[d[1] for d in datasets],
-        type=String[d[2] for d in datasets],
-        dimensions=String[d[3] for d in datasets],
-        description=String[d[4] for d in datasets]
+        name=String[String(d) for d in EXAMPLE_DATASETS],
+        type=String[info(d)[1] for d in EXAMPLE_DATASETS],
+        dimensions=String[info(d)[2] for d in EXAMPLE_DATASETS],
+        description=String[info(d)[3] for d in EXAMPLE_DATASETS]
     )
 
     output_result(df; format=Symbol(format), output=output, title="Available Datasets")
 end
 
-function _data_load(; name::String, output::String="", format::String="table",
+function _data_load(; name::String="", output::String="", format::String="table",
                      vars::String="", country::String="", transform::Bool=false,
                      dates::String="", path::String="")
+    if isempty(name) && isempty(path)
+        throw(CliError("usage/missing",
+                       "give an example dataset name or --path <file.csv>";
+                       hint="run 'friedman data list' to see the available datasets"))
+    end
+
     # If --path is given, load from CSV instead of example datasets
     if !isempty(path)
+        isempty(name) || _status("Both <name> and --path given; loading --path $path")
+        path = expanduser(path)
         df = load_data(path)
         Y = df_to_matrix(df)
         vn = variable_names(df)
@@ -232,7 +251,7 @@ function _data_load(; name::String, output::String="", format::String="table",
             end
         end
 
-        out_path = isempty(output) ? replace(basename(path), r"\.[^.]+$" => "_loaded.csv") : output
+        out_path = isempty(output) ? "$(dataset_stem(path))_loaded.csv" : output
         _validate_output_path(out_path)
         out_df = DataFrame(Y, vn)
         CSV.write(out_path, out_df)
@@ -241,7 +260,8 @@ function _data_load(; name::String, output::String="", format::String="table",
         return
     end
 
-    name_sym = Symbol(name)
+    name_sym = parse_dataset_name(name)
+    name = String(name_sym)   # canonical stem for messages and default output paths
     dataset = load_example(name_sym)
 
     if dataset isa PanelData
@@ -263,7 +283,9 @@ function _data_load(; name::String, output::String="", format::String="table",
             var_list = [strip(s) for s in split(vars, ",") if !isempty(strip(s))]
             keep_cols = ["group", "time"]
             for v in var_list
-                v in vn || error("variable '$v' not found in $name (available: $(join(vn[1:min(5, length(vn))], ", "))...)")
+                v in vn || throw(CliError("data/column-range",
+                    "variable '$v' not found in $name";
+                    hint="available: $(join(vn[1:min(5, length(vn))], ", "))..."))
                 push!(keep_cols, v)
             end
             df = df[!, keep_cols]
@@ -273,11 +295,14 @@ function _data_load(; name::String, output::String="", format::String="table",
         _status("Loaded $name: $n_obs observations × $n_vars variables (Panel, $(dataset.n_groups) groups)")
         _status("Written to $out_path")
     else
-        # TimeSeriesData
+        # TimeSeriesData, or a CrossSectionData set with no time dimension
+        is_ts = dataset isa TimeSeriesData
         data_mat = to_matrix(dataset)
         vn = varnames(dataset)
 
         if transform
+            is_ts || throw(CliError("usage/invalid",
+                "--transform applies FRED transformation codes, which $name (cross section) does not have"))
             dataset = apply_tcode(dataset, dataset.tcode)
             data_mat = to_matrix(dataset)
             _status("Applied FRED transformation codes")
@@ -288,14 +313,16 @@ function _data_load(; name::String, output::String="", format::String="table",
             col_idx = Int[]
             for v in var_list
                 idx = findfirst(==(v), vn)
-                isnothing(idx) && error("variable '$v' not found in $name (available: $(join(vn[1:min(5, length(vn))], ", "))...)")
+                isnothing(idx) && throw(CliError("data/column-range",
+                    "variable '$v' not found in $name";
+                    hint="available: $(join(vn[1:min(5, length(vn))], ", "))..."))
                 push!(col_idx, idx)
             end
             data_mat = data_mat[:, col_idx]
             vn = vn[col_idx]
         end
 
-        if !isempty(dates)
+        if !isempty(dates) && is_ts
             # For named datasets, dates column would need to be in the variable names
             if dates in vn
                 date_values = string.(data_mat[:, findfirst(==(dates), vn)])
@@ -311,8 +338,9 @@ function _data_load(; name::String, output::String="", format::String="table",
         n_obs, n_vars = size(data_mat)
         df = DataFrame(data_mat, vn)
         CSV.write(out_path, df)
-        freq_str = string(frequency(dataset))
-        _status("Loaded $name: $n_obs × $n_vars ($freq_str)")
+        # `frequency` is only defined for time-series/panel sets, not cross sections.
+        kind = is_ts ? string(frequency(dataset)) : "Cross Section"
+        _status("Loaded $name: $n_obs × $n_vars ($kind)")
         _status("Written to $out_path")
     end
 end
@@ -328,7 +356,7 @@ function _data_describe(; data::String, format::String="table", output::String="
 
     result_df = DataFrame(
         variable=vn,
-        n=fill(summary.n, n_vars),
+        n=summary.n,   # already per-variable; fill() nested a vector into every cell
         mean=round.(summary.mean; digits=4),
         std=round.(summary.std; digits=4),
         min=round.(summary.min; digits=4),
@@ -392,8 +420,7 @@ function _data_fix(; data::String, method::String="listwise", output::String="",
     out_path = if !isempty(output)
         output
     else
-        base = replace(basename(data), r"\.[^.]+$" => "")
-        "$(base)_clean.csv"
+        "$(dataset_stem(data))_clean.csv"
     end
     _validate_output_path(out_path)
 
@@ -409,10 +436,13 @@ function _data_transform(; data::String, tcodes::String="", output::String="", f
     vn = variable_names(df)
     n_obs, n_vars = size(Y)
 
-    isempty(tcodes) && error("--tcodes is required (comma-separated FRED transformation codes, e.g., 5,5,1,6)")
+    isempty(tcodes) && throw(CliError("usage/missing",
+        "--tcodes is required";
+        hint="comma-separated FRED transformation codes, e.g. --tcodes 5,5,1,6"))
 
     codes = [parse(Int, strip(s)) for s in split(tcodes, ",") if !isempty(strip(s))]
-    length(codes) == n_vars || error("number of tcodes ($(length(codes))) must match number of variables ($n_vars)")
+    length(codes) == n_vars || throw(CliError("usage/invalid",
+        "number of tcodes ($(length(codes))) must match number of variables ($n_vars)"))
 
     tsd = TimeSeriesData(Y; varnames=vn, tcode=codes, time_index=collect(1:n_obs))
     transformed = apply_tcode(tsd, codes)
@@ -423,8 +453,7 @@ function _data_transform(; data::String, tcodes::String="", output::String="", f
     out_path = if !isempty(output)
         output
     else
-        base = replace(basename(data), r"\.[^.]+$" => "")
-        "$(base)_transformed.csv"
+        "$(dataset_stem(data))_transformed.csv"
     end
     _validate_output_path(out_path)
 

--- a/src/commands/test.jl
+++ b/src/commands/test.jl
@@ -2798,7 +2798,7 @@ function _test_cips(; data::String, lags::String="auto",
     result = pesaran_cips_test(dat; lags=lags_arg, deterministic=Symbol(deterministic))
 
     pairs = Pair{String,Any}[
-        "CIPS statistic" => round(result.cips; digits=4),
+        "CIPS statistic" => round(result.cips_statistic; digits=4),
         "p-value" => round(result.pvalue; digits=4),
         "Lags" => result.lags,
         "Deterministic" => result.deterministic,

--- a/src/io.jl
+++ b/src/io.jl
@@ -119,17 +119,97 @@ function _validate_output_path(path::String)
     return path
 end
 
+# ── Example datasets ─────────────────────────────────────
+
+"""
+Bundled MEMs example datasets that load as a rectangular table.
+
+Single source of truth for `data list`, `data load <name>`, `load_data(":name")`
+and the REPL's `data use :name` — keep every dataset-name surface derived from
+this tuple so they cannot drift apart again.
+
+`:wiot` is deliberately absent: it is an `IOData` archive with no `data`/`varnames`
+and is served by the `io` command family instead.
+"""
+const EXAMPLE_DATASETS = (
+    :fred_md, :fred_qd, :pwt, :mpdta, :ddcg,
+    :denmark, :gnp_hamilton, :grunfeld, :mroz, :nile, :stackloss,
+)
+
+"""
+    parse_dataset_name(name) → Symbol
+
+Normalize a user-supplied example-dataset name to its MEMs symbol.
+
+Accepts an optional leading `:` and either spelling of the separator, so
+`fred_md`, `fred-md`, `:fred_md` and `:fred-md` all resolve to `:fred_md`.
+Throws a typed `data/unknown-dataset` (exit 3) with a nearest-match hint for
+anything else — never let the raw `ArgumentError` from `load_example` escape,
+which surfaces as an exit-1 "likely a bug".
+"""
+function parse_dataset_name(name::AbstractString)
+    stem = String(strip(name))
+    startswith(stem, ":") && (stem = stem[2:end])
+    sym = Symbol(replace(lowercase(stem), "-" => "_"))
+    sym in EXAMPLE_DATASETS && return sym
+
+    known = String[String(d) for d in EXAMPLE_DATASETS]
+    hint = if sym === :wiot
+        "the wiot input-output table is served by the 'io' family, e.g. 'friedman io leontief'"
+    else
+        sugg = _nearest(replace(lowercase(stem), "-" => "_"), known)
+        isnothing(sugg) ? "run 'friedman data list' to see the available datasets" :
+                          "did you mean '$sugg'?"
+    end
+    throw(CliError("data/unknown-dataset",
+                   "unknown dataset '$name' (available: $(join(known, ", ")))"; hint=hint))
+end
+
+"""
+    dataset_to_dataframe(dataset) → DataFrame
+
+Convert a loaded MEMs example dataset to a DataFrame.
+
+Panel datasets keep their identifiers as leading `group`/`time` columns — without
+them every panel command (`estimate pvar`, `test cips`, …) fails on a bundled
+panel because `--id-col`/`--time-col` have nothing to bind to.
+"""
+function dataset_to_dataframe(dataset)
+    df = DataFrame(to_matrix(dataset), varnames(dataset); makeunique=true)
+    if dataset isa PanelData
+        insertcols!(df, 1, :group => dataset.group_id, :time => dataset.time_id;
+                    makeunique=true)
+    end
+    return df
+end
+
+"""
+    dataset_stem(source) → String
+
+Filename stem for a data source, used to build default output paths.
+
+Strips the `:` marker from a dataset reference (so `:fred-md` yields `fred_md`,
+not a file literally named `:fred-md_clean.csv`) and the extension from a path.
+"""
+function dataset_stem(source::AbstractString)
+    s = String(source)
+    startswith(s, ":") && return replace(lowercase(s[2:end]), "-" => "_")
+    return replace(basename(s), r"\.[^.]+$" => "")
+end
+
 """
     load_data(path) → DataFrame
 
 Read a CSV file and return a DataFrame. Validates that the file exists and is non-empty.
+
+A `:name` reference (e.g. `:fred_md`) loads a bundled example dataset instead.
+`~` is expanded here rather than relying on the shell, because the REPL has none.
 """
 function load_data(path::String)
     if startswith(path, ":")
-        name = Symbol(replace(path[2:end], "-" => "_"))
-        ts = load_example(name)
-        return DataFrame(ts.data, ts.varnames)
+        return dataset_to_dataframe(load_example(parse_dataset_name(path)))
     end
+    path = expanduser(path)
     _validate_input_path(path)
     isfile(path) || throw(CliError("data/file-not-found", "file not found: $path"; hint="check the path"))
     df = CSV.read(path, DataFrame)

--- a/src/io.jl
+++ b/src/io.jl
@@ -93,6 +93,34 @@ end
 # ── Path Validation ──────────────────────────────────────
 
 """
+    _expanduser(path) → String
+
+Expand a leading `~` on every platform.
+
+`Base.expanduser` is a no-op on Windows (there `~` historically marks a temporary
+file), so relying on it would make `~/data.csv` work on macOS/Linux and fail with a
+bare file-not-found on Windows — the CLI is agent-first and must behave identically
+on all three. `~user` forms are returned untouched: Base throws an untyped
+`ArgumentError` for them, which would surface as an internal error (exit 1) instead
+of the normal typed `data/file-not-found`.
+"""
+function _expanduser(path::AbstractString)
+    p = String(path)
+    startswith(p, "~") || return p
+    length(p) == 1 && return homedir()
+    if Sys.iswindows()
+        c = p[2]
+        (c == '/' || c == '\\') || return p          # `~user\...` — leave for the caller to report
+        return joinpath(homedir(), lstrip(ch -> ch == '/' || ch == '\\', p[3:end]))
+    end
+    return try
+        expanduser(p)
+    catch e
+        e isa ArgumentError ? p : rethrow()          # `~user/...` is unimplemented in Base
+    end
+end
+
+"""
     _validate_input_path(path) → String
 
 Validate that an input file path does not contain path traversal sequences (`..`).
@@ -209,7 +237,7 @@ function load_data(path::String)
     if startswith(path, ":")
         return dataset_to_dataframe(load_example(parse_dataset_name(path)))
     end
-    path = expanduser(path)
+    path = _expanduser(path)
     _validate_input_path(path)
     isfile(path) || throw(CliError("data/file-not-found", "file not found: $path"; hint="check the path"))
     df = CSV.read(path, DataFrame)

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -26,6 +26,9 @@ end
 Session() = Session("", nothing, nothing, String[], Dict{Symbol,Any}(), :none)
 
 function session_load_data!(s::Session, path::String)
+    # `~` has no shell to expand it inside the REPL; store the expanded path so
+    # every downstream command that receives it via inject_session_data resolves.
+    path = startswith(path, ":") ? path : expanduser(path)
     df = load_data(path)
     Y = df_to_matrix(df)
     vnames = variable_names(df)
@@ -58,32 +61,27 @@ session_has_data(s::Session) = !isempty(s.data_path)
 
 session_get_result(s::Session, model_type::Symbol) = get(s.results, model_type, nothing)
 
-const BUILTIN_DATASETS = Dict(
-    "fred-md" => :fred_md, "fred-qd" => :fred_qd,
-    "pwt" => :pwt, "mpdta" => :mpdta, "ddcg" => :ddcg,
-)
+"""
+    parse_data_source(source) → (:builtin, Symbol) | (:file, String)
 
+Classify a `data use` argument. A leading `:` marks a bundled example dataset,
+resolved through the shared `parse_dataset_name` so the REPL accepts exactly the
+names `data list`/`data load` advertise (either separator spelling).
+"""
 function parse_data_source(source::String)
-    if startswith(source, ":")
-        name = source[2:end]
-        haskey(BUILTIN_DATASETS, name) || error("unknown built-in dataset ':$name'. Available: $(join(keys(BUILTIN_DATASETS), ", "))")
-        return (:builtin, BUILTIN_DATASETS[name])
-    else
-        return (:file, source)
-    end
+    startswith(source, ":") && return (:builtin, parse_dataset_name(source))
+    return (:file, source)
 end
 
+"""
+    session_load_builtin!(session, name)
+
+Load a bundled example dataset into the session. Delegates to `session_load_data!`
+via the canonical `:name` reference so builtins and files take one code path —
+in particular panel datasets keep their `group`/`time` id columns.
+"""
 function session_load_builtin!(s::Session, name::Symbol)
-    ts = load_example(name)
-    df = DataFrame(ts.data, ts.varnames)
-    Y = Matrix{Float64}(ts.data)
-    s.data_path = ":$(replace(string(name), "_" => "-"))"
-    s.df = df
-    s.Y = Y
-    s.varnames = ts.varnames
-    s.results = Dict{Symbol,Any}()
-    s.last_model = :none
-    return s
+    return session_load_data!(s, ":$(name)")
 end
 
 """

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -28,7 +28,7 @@ Session() = Session("", nothing, nothing, String[], Dict{Symbol,Any}(), :none)
 function session_load_data!(s::Session, path::String)
     # `~` has no shell to expand it inside the REPL; store the expanded path so
     # every downstream command that receives it via inject_session_data resolves.
-    path = startswith(path, ":") ? path : expanduser(path)
+    path = startswith(path, ":") ? path : _expanduser(path)
     df = load_data(path)
     Y = df_to_matrix(df)
     vnames = variable_names(df)

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -2668,6 +2668,101 @@ col_index(tbl, name::AbstractString) = findfirst(==(name), table_cols(tbl))
             rm(csv; force=true)
         end
     end
+
+    # ── Data loading on real MEMs ────────────────────────────────────────────
+    # This family had NO T3 coverage, which is why a broken `data load --path`,
+    # a `:name` reference that exited 1, and panel datasets that silently lost
+    # their id columns all survived. Keep these here.
+    @testset "data loading (real load_example)" begin
+        @testset "data load --path without a positional name" begin
+            mktempdir() do dir
+                src = joinpath(dir, "mine.csv")
+                CSV.write(src, DataFrame(a=randn(30), b=randn(30)))
+                out = joinpath(dir, "out.csv")
+                # Regression: <name> used to be required → "missing required argument"
+                @test run_json(["data", "load", "--path", src, "-o", out]).code == 0
+                @test isfile(out)
+                @test nrow(CSV.read(out, DataFrame)) == 30
+            end
+        end
+
+        @testset "dataset names: ':' refs, both separators, typos" begin
+            mktempdir() do dir
+                for (i, form) in enumerate(["fred_md", "fred-md", ":fred-md", ":fred_md"])
+                    out = joinpath(dir, "d$i.csv")
+                    # Regression: ':fred-md' raised an untyped ArgumentError → exit 1
+                    @test run_json(["data", "load", form, "-o", out]).code == 0
+                    @test isfile(out)
+                end
+            end
+            # Unknown name → typed data error (exit 3), never the exit-1 "likely a bug" tail
+            @test run_json(["data", "load", "frd_md"]).code == 3
+            @test run_json(["data", "load", ":wiot"]).code == 3
+            # Neither a name nor --path → usage error (exit 2)
+            @test run_json(["data", "load"]).code == 2
+        end
+
+        @testset "every advertised dataset actually loads" begin
+            # data list is built from EXAMPLE_DATASETS; assert the list is honest.
+            mktempdir() do dir
+                for (i, d) in enumerate(Friedman.EXAMPLE_DATASETS)
+                    out = joinpath(dir, "ds$i.csv")
+                    r = run_json(["data", "load", String(d), "-o", out])
+                    @test r.code == 0
+                    @test isfile(out)
+                end
+            end
+        end
+
+        @testset "builtin panels keep their group/time identifiers" begin
+            # Without this, every panel command fails on a bundled panel dataset.
+            df = Friedman.load_data(":pwt")
+            @test "group" in names(df)
+            @test "time" in names(df)
+            # …and a real panel command can bind to them end-to-end.
+            r = run_json(["test", "cips", ":grunfeld", "--id-col", "group",
+                          "--time-col", "time", "--lags", "1"])
+            @test r.code == 0
+        end
+
+        @testset "default output paths never contain the ':' marker" begin
+            mktempdir() do dir
+                cd(dir) do
+                    # Regression: produced a file literally named ':fred-md_clean.csv'
+                    @test run_json(["data", "fix", ":denmark"]).code == 0
+                    @test isfile(joinpath(dir, "denmark_clean.csv"))
+                    @test !isfile(joinpath(dir, ":denmark_clean.csv"))
+                end
+            end
+        end
+
+        @testset "data describe reports a scalar n per variable" begin
+            mktempdir() do dir
+                src = joinpath(dir, "d.csv")
+                CSV.write(src, DataFrame(a=randn(50), b=randn(50)))
+                r = run_json(["data", "describe", src])
+                @test r.code == 0
+                _, tbl = first_table(r.doc)
+                @test tbl !== nothing
+                if tbl !== nothing
+                    ni = findfirst(==("n"), table_cols(tbl))
+                    @test ni !== nothing
+                    # Regression: fill(summary.n, n_vars) put the whole vector in every cell
+                    @test all(row -> collect(row)[ni] isa Integer, table_rows(tbl))
+                    @test all(row -> collect(row)[ni] == 50, table_rows(tbl))
+                end
+            end
+        end
+
+        @testset "~ is expanded by the loader (the REPL has no shell)" begin
+            mktempdir() do dir
+                CSV.write(joinpath(dir, "tilde.csv"), DataFrame(a=randn(20)))
+                withenv("HOME" => dir) do
+                    @test nrow(Friedman.load_data("~/tilde.csv")) == 20
+                end
+            end
+        end
+    end
 end
 
 # Real entry-point coverage (C036) — also on core/CI path

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -1862,6 +1862,12 @@ function TimeSeriesData(data::AbstractMatrix{T}; varnames=String[], frequency=:u
     TimeSeriesData{T}(Matrix{T}(data), varnames, frequency, tcode, time_index, desc, vardesc)
 end
 
+# Field order is a prefix of the real CrossSectionData (source_refs omitted).
+struct CrossSectionData{T<:Real}
+    data::Matrix{T}; varnames::Vector{String}; obs_id::Vector{Int}
+    N_obs::Int; n_vars::Int; desc::String; vardesc::Vector{String}
+end
+
 struct DataDiagnostic
     n_nan::Vector{Int}; n_inf::Vector{Int}; is_constant::Vector{Bool}
     is_short::Bool; is_clean::Bool
@@ -1917,18 +1923,56 @@ function load_example(name::Symbol)
         group_ids = repeat(1:n_groups, inner=n_years)
         time_ids = repeat(1960:2010, outer=n_groups)
         PanelData(data, vn, group_ids, time_ids, n_groups, n_vars, T_obs, true)
+    elseif name == :denmark
+        # Johansen-Juselius Danish money demand: 55 quarters × 5 vars
+        T_obs = 55
+        vn = ["LRM", "LRY", "LPY", "IBO", "IDE"]
+        TimeSeriesData(randn(T_obs, 5) .+ 1.0, vn, :quarterly, fill(1, 5),
+            collect(1:T_obs), "Danish money demand", ["Variable $v" for v in vn])
+    elseif name == :gnp_hamilton
+        # Hamilton (1989) US GNP growth: 135 quarters × 1 var
+        T_obs = 135
+        TimeSeriesData(randn(T_obs, 1) .+ 1.0, ["gnp_growth"], :quarterly, [1],
+            collect(1:T_obs), "US GNP growth (Hamilton 1989)", ["GNP growth"])
+    elseif name == :nile
+        # Nile annual flow: 100 years × 1 var
+        T_obs = 100
+        TimeSeriesData(randn(T_obs, 1) .+ 900.0, ["flow"], :annual, [1],
+            collect(1:T_obs), "Nile river annual flow", ["Flow"])
+    elseif name == :grunfeld
+        # Grunfeld investment panel: 10 firms × 20 years × 3 vars
+        n_groups = 10; n_years = 20; n_vars = 3
+        T_obs = n_groups * n_years
+        vn = ["invest", "value", "capital"]
+        group_ids = repeat(1:n_groups, inner=n_years)
+        time_ids = repeat(1935:1954, outer=n_groups)
+        PanelData(randn(T_obs, n_vars) .+ 1.0, vn, group_ids, time_ids,
+                  n_groups, n_vars, T_obs, true)
+    elseif name == :mroz
+        # Mroz (1987) female labour supply: 753 × 22 cross section
+        vn = vcat(["inlf", "hours", "kidslt6", "kidsge6"], ["var$i" for i in 5:22])
+        CrossSectionData(randn(753, 22) .+ 1.0, vn, collect(1:753), 753, 22,
+                         "Mroz (1987) female labour supply", ["Variable $v" for v in vn])
+    elseif name == :stackloss
+        # Brownlee stack-loss plant data: 21 × 4 cross section
+        vn = ["stackloss", "airflow", "watertemp", "acidconc"]
+        CrossSectionData(randn(21, 4) .+ 1.0, vn, collect(1:21), 21, 4,
+                         "Brownlee stack loss", ["Variable $v" for v in vn])
     elseif name == :wiot
         _mock_wiot()   # Miller & Blair (2009) IO fixture (defined below)
     else
         # Real load_example throws ArgumentError — match it so error-mapping is testable.
-        throw(ArgumentError("Unknown dataset :$name. Available: fred_md, fred_qd, pwt, mpdta, ddcg, wiot"))
+        throw(ArgumentError("Unknown dataset :$name. Available: fred_md, fred_qd, pwt, mpdta, ddcg, " *
+                            "denmark, gnp_hamilton, grunfeld, mroz, nile, stackloss, wiot"))
     end
 end
 
 to_matrix(d::TimeSeriesData) = d.data
 to_matrix(d::PanelData) = d.data
+to_matrix(d::CrossSectionData) = d.data
 varnames(d::TimeSeriesData) = d.varnames
 varnames(d::PanelData) = d.varnames
+varnames(d::CrossSectionData) = d.varnames
 frequency(d::TimeSeriesData) = d.frequency
 desc(d::TimeSeriesData) = d.desc
 vardesc(d::TimeSeriesData) = d.vardesc
@@ -6223,11 +6267,10 @@ function Base.getproperty(m::BayesianFAVAR, s::Symbol)
     s === :n_draws && return size(getfield(m, :B_draws), 3)
     return getfield(m, s)
 end
-function Base.getproperty(m::PesaranCIPSResult, s::Symbol)
-    s === :cips && return getfield(m, :cips_statistic)
-    s === :individual_cadf && return getfield(m, :individual_cadf_stats)
-    return getfield(m, s)
-end
+# NOTE: no `cips`/`individual_cadf` aliases here. Real MEMs 0.7.0 exposes only
+# `cips_statistic`/`individual_cadf_stats`; the aliases this mock used to provide
+# hid a handler that read `result.cips` and crashed (exit 1) on real MEMs.
+# Keep the mock's property surface a subset of the real one.
 function Base.getproperty(m::FactorBreakResult, s::Symbol)
     s === :r && return getfield(m, :n_factors)
     s === :n_units && return getfield(m, :n_vars)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2843,6 +2843,57 @@ end
         @test_throws CliError load_data("data/../../../secret.csv")
     end
 
+    @testset "load_data expands ~" begin
+        # The REPL has no shell, so `~` must be expanded by the loader itself.
+        mktempdir() do dir
+            csv_path = joinpath(dir, "tilde.csv")
+            CSV.write(csv_path, DataFrame(a=[1.0, 2.0]))
+            # A path that expands to a real file loads; the raw `~` form would not.
+            withenv("HOME" => dir) do
+                df = load_data("~/tilde.csv")
+                @test nrow(df) == 2
+            end
+        end
+        # `~` is expanded before the not-found check, so the message shows the real path.
+        e = try; load_data("~/definitely-not-a-real-file-9f3a.csv"); nothing
+            catch err; err end
+        @test e isa CliError
+        @test !contains(e.message, "~")
+    end
+
+    @testset "parse_dataset_name" begin
+        # Both separator spellings and an optional leading ':' resolve to the MEMs symbol
+        for form in (":fred-md", ":fred_md", "fred-md", "fred_md", "FRED_MD", " fred_md ")
+            @test parse_dataset_name(form) == :fred_md
+        end
+        @test parse_dataset_name("pwt") == :pwt
+        @test parse_dataset_name(":nile") == :nile
+
+        # Unknown → typed data/unknown-dataset (never an untyped exit-1 ArgumentError)
+        e = try; parse_dataset_name("frd_md"); nothing catch err; err end
+        @test e isa CliError
+        @test e.code == "data/unknown-dataset"
+        @test contains(e.hint, "fred_md")           # nearest-match suggestion
+
+        # :wiot is real but IO-shaped — point at the io family rather than a typo hint
+        e2 = try; parse_dataset_name(":wiot"); nothing catch err; err end
+        @test e2 isa CliError
+        @test e2.code == "data/unknown-dataset"
+        @test contains(e2.hint, "io")
+
+        e3 = try; parse_dataset_name("zzzz"); nothing catch err; err end
+        @test e3 isa CliError
+        @test contains(e3.hint, "data list")
+    end
+
+    @testset "dataset_stem" begin
+        # A ':' dataset ref must not leak into a filename (regression: ':fred-md_clean.csv')
+        @test dataset_stem(":fred-md") == "fred_md"
+        @test dataset_stem(":pwt") == "pwt"
+        @test dataset_stem("data/my file.csv") == "my file"
+        @test dataset_stem("noext") == "noext"
+    end
+
     @testset "output path traversal rejection" begin
         df = DataFrame(a=[1,2,3])
         @test_throws CliError output_result(df; format=:csv, output="../bad.csv")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2844,21 +2844,35 @@ end
     end
 
     @testset "load_data expands ~" begin
-        # The REPL has no shell, so `~` must be expanded by the loader itself.
+        # The REPL has no shell, so `~` must be expanded by the loader itself — on every
+        # platform (Base.expanduser is a no-op on Windows, hence io.jl's own _expanduser).
         mktempdir() do dir
-            csv_path = joinpath(dir, "tilde.csv")
-            CSV.write(csv_path, DataFrame(a=[1.0, 2.0]))
-            # A path that expands to a real file loads; the raw `~` form would not.
-            withenv("HOME" => dir) do
-                df = load_data("~/tilde.csv")
-                @test nrow(df) == 2
+            # homedir() reads HOME on unix and USERPROFILE on Windows (libuv), so set
+            # both, then write to whatever `~` actually resolves to on this platform.
+            withenv("HOME" => dir, "USERPROFILE" => dir) do
+                csv_path = joinpath(homedir(), "tilde.csv")
+                CSV.write(csv_path, DataFrame(a=[1.0, 2.0]))
+                try
+                    # A path that expands to a real file loads; the raw `~` form would not.
+                    @test nrow(load_data("~/tilde.csv")) == 2
+                    # PowerShell users type the native separator.
+                    Sys.iswindows() && @test nrow(load_data("~\\tilde.csv")) == 2
+                finally
+                    rm(csv_path; force=true)
+                end
             end
         end
         # `~` is expanded before the not-found check, so the message shows the real path.
         e = try; load_data("~/definitely-not-a-real-file-9f3a.csv"); nothing
             catch err; err end
         @test e isa CliError
-        @test !contains(e.message, "~")
+        @test contains(e.message, homedir())
+        # `~user` is unimplemented in Base and throws an untyped ArgumentError; the
+        # loader must leave it alone and report the usual typed not-found instead.
+        e2 = try; load_data("~nosuchuser/definitely-not-a-real-file-9f3a.csv"); nothing
+             catch err; err end
+        @test e2 isa CliError
+        @test e2.code == "data/file-not-found"
     end
 
     @testset "parse_dataset_name" begin

--- a/test/test_commands.jl
+++ b/test/test_commands.jl
@@ -6195,6 +6195,40 @@ end  # Enhanced Granger handlers
         @test length(node.subcmds["balance"].options) == 5
     end
 
+    @testset "dataset_to_dataframe — panels keep their identifiers" begin
+        # Without group/time columns every panel command fails on a bundled panel
+        # (`--id-col group` has nothing to bind to).
+        df = dataset_to_dataframe(load_example(:pwt))
+        @test names(df)[1:2] == ["group", "time"]
+        @test df.group == load_example(:pwt).group_id
+
+        # Same via the public loader used by handlers and the REPL
+        df2 = load_data(":pwt")
+        @test "group" in names(df2) && "time" in names(df2)
+
+        # Non-panel datasets are unchanged
+        ts = dataset_to_dataframe(load_example(:fred_md))
+        @test !("group" in names(ts))
+
+        # Cross-section datasets load too (added alongside the other bundled sets)
+        cs = dataset_to_dataframe(load_example(:stackloss))
+        @test nrow(cs) == 21
+    end
+
+    @testset "_data_describe — n is per-variable" begin
+        mktempdir() do dir
+            csv = joinpath(dir, "d.csv")
+            CSV.write(csv, DataFrame(a=[1.0, 2.0, 3.0], b=[4.0, 5.0, 6.0]))
+            outfile = joinpath(dir, "desc.json")
+            _capture() do
+                _data_describe(; data=csv, format="json", output=outfile)
+            end
+            rows = JSON3.read(read(outfile, String))
+            # Regression: fill(summary.n, n_vars) nested the whole vector into every cell
+            @test all(r -> r.n isa Integer, rows)
+        end
+    end
+
     @testset "_data_list — table" begin
         out = _capture() do
             _data_list(; format="table")
@@ -6209,8 +6243,56 @@ end  # Enhanced Granger handlers
             end
             @test isfile(outfile)
             json_data = JSON3.read(read(outfile, String))
-            @test length(json_data) == 5
+            # Derived from EXAMPLE_DATASETS, so `data list` can never advertise
+            # fewer datasets than `data load` accepts.
+            @test length(json_data) == length(EXAMPLE_DATASETS)
         end
+    end
+
+    @testset "_data_load — loading existing data (regressions)" begin
+        node = register_data_commands!()
+        load_leaf = node.subcmds["load"]
+
+        # <name> is optional so `data load --path file.csv` is reachable at all.
+        @test !load_leaf.args[1].required
+        # --transform was documented + handler-supported but never registered.
+        @test "transform" in [f.name for f in load_leaf.flags]
+
+        mktempdir() do dir
+            src = joinpath(dir, "mine.csv")
+            CSV.write(src, DataFrame(a=[1.0, 2.0, 3.0], b=[4.0, 5.0, 6.0]))
+
+            # --path alone (no positional) loads the CSV
+            cd(dir) do
+                _capture() do
+                    _data_load(; path=src)
+                end
+            end
+            @test isfile(joinpath(dir, "mine_loaded.csv"))
+
+            # Neither name nor --path → typed usage error, not a missing-arg crash
+            e = try; _capture() do; _data_load(); end; nothing catch err; err end
+            @test e isa CliError
+            @test e.code == "usage/missing"
+        end
+
+        # ':name' references resolve (REPL syntax must work on the CLI too)
+        for form in ("fred-md", ":fred-md", ":fred_md")
+            mktempdir() do dir
+                cd(dir) do
+                    _capture() do
+                        _data_load(; name=form)
+                    end
+                end
+                # Default output uses the canonical stem — never ':fred-md.csv'
+                @test isfile(joinpath(dir, "fred_md.csv"))
+            end
+        end
+
+        # Unknown dataset → typed data/unknown-dataset (was untyped ArgumentError → exit 1)
+        e = try; _capture() do; _data_load(; name="frd_md"); end; nothing catch err; err end
+        @test e isa CliError
+        @test e.code == "data/unknown-dataset"
     end
 
     @testset "_data_load — fred_md" begin
@@ -8671,6 +8753,9 @@ end
                 _test_cips(; data=csv, lags="2", deterministic="constant",
                              id_col="", time_col="", format="table")
             end
+            # Regression: the handler read `result.cips`, a field real MEMs does not
+            # have (it is `cips_statistic`) — a mock getproperty alias hid the crash.
+            @test contains(out, "CIPS statistic")
         end
     end
 

--- a/test/test_repl.jl
+++ b/test/test_repl.jl
@@ -4,8 +4,29 @@ using CSV, DataFrames
 # Set up minimal Friedman context for testing repl.jl
 module Friedman
     using CSV, DataFrames
+
     # Minimal stubs matching io.jl functions
+    struct CliError <: Exception
+        code::String; message::String; hint::String
+    end
+    CliError(code::String, message::String; hint::String="") = CliError(code, message, hint)
+
+    const EXAMPLE_DATASETS = (:fred_md, :fred_qd, :pwt, :mpdta, :ddcg)
+
+    function parse_dataset_name(name::AbstractString)
+        stem = String(strip(name))
+        startswith(stem, ":") && (stem = stem[2:end])
+        sym = Symbol(replace(lowercase(stem), "-" => "_"))
+        sym in EXAMPLE_DATASETS && return sym
+        throw(CliError("data/unknown-dataset", "unknown dataset '$name'"))
+    end
+
     function load_data(path::String)
+        if startswith(path, ":")
+            ds = load_example(parse_dataset_name(path))
+            return DataFrame(ds.data, ds.varnames; makeunique=true)
+        end
+        path = expanduser(path)
         isfile(path) || error("file not found: $path")
         df = CSV.read(path, DataFrame)
         nrow(df) == 0 && error("empty dataset: $path")
@@ -201,13 +222,19 @@ end
         @test Friedman.parse_data_source(":mpdta") == (:builtin, :mpdta)
         @test Friedman.parse_data_source(":ddcg") == (:builtin, :ddcg)
         @test Friedman.parse_data_source("myfile.csv") == (:file, "myfile.csv")
-        @test_throws ErrorException Friedman.parse_data_source(":nonexistent")
+        @test_throws Friedman.CliError Friedman.parse_data_source(":nonexistent")
+
+        # Both separator spellings resolve — `data list`/`data load` say `fred_md`,
+        # so the REPL must not reject it (regression: underscore form was an error).
+        @test Friedman.parse_data_source(":fred_md") == (:builtin, :fred_md)
+        @test Friedman.parse_data_source(":fred_qd") == (:builtin, :fred_qd)
+        @test Friedman.parse_data_source(":FRED-MD") == (:builtin, :fred_md)
     end
 
     @testset "session_load_builtin!" begin
         s = Friedman.Session()
         Friedman.session_load_builtin!(s, :fred_md)
-        @test s.data_path == ":fred-md"
+        @test s.data_path == ":fred_md"
         @test !isnothing(s.df)
         @test !isnothing(s.Y)
         @test size(s.Y) == (3, 3)
@@ -382,7 +409,7 @@ end
         s = Friedman.Session()
         app = Friedman.build_app()
         Friedman.repl_dispatch(s, app, ["data", "use", ":fred-md"])
-        @test s.data_path == ":fred-md"
+        @test s.data_path == ":fred_md"
         @test s.varnames == ["INDPRO", "CPI", "FEDFUNDS"]
     end
 
@@ -418,7 +445,7 @@ end
                 try; rm(tmppath; force=true); catch; end
             end
         end
-        @test contains(output2, ":fred-md")
+        @test contains(output2, ":fred_md")
         @test contains(output2, "3×3")
     end
 
@@ -571,7 +598,7 @@ end
     @testset "builtin dataset workflow" begin
         s = Friedman.Session()
         Friedman.session_load_builtin!(s, :fred_md)
-        @test s.data_path == ":fred-md"
+        @test s.data_path == ":fred_md"
         @test !isnothing(s.Y)
 
         # Store result

--- a/test/test_repl.jl
+++ b/test/test_repl.jl
@@ -21,12 +21,29 @@ module Friedman
         throw(CliError("data/unknown-dataset", "unknown dataset '$name'"))
     end
 
+    # Mirrors io.jl: Base.expanduser is a no-op on Windows, so repl.jl uses ours.
+    function _expanduser(path::AbstractString)
+        p = String(path)
+        startswith(p, "~") || return p
+        length(p) == 1 && return homedir()
+        if Sys.iswindows()
+            c = p[2]
+            (c == '/' || c == '\\') || return p
+            return joinpath(homedir(), lstrip(ch -> ch == '/' || ch == '\\', p[3:end]))
+        end
+        return try
+            expanduser(p)
+        catch e
+            e isa ArgumentError ? p : rethrow()
+        end
+    end
+
     function load_data(path::String)
         if startswith(path, ":")
             ds = load_example(parse_dataset_name(path))
             return DataFrame(ds.data, ds.varnames; makeunique=true)
         end
-        path = expanduser(path)
+        path = _expanduser(path)
         isfile(path) || error("file not found: $path")
         df = CSV.read(path, DataFrame)
         nrow(df) == 0 && error("empty dataset: $path")


### PR DESCRIPTION
Loading existing data was broken in the REPL and on the CLI. The `data` family had **no T3 coverage**, and ten defects had accumulated on that path. All are fixed and regression-tested at T1/T2 **and** T3.

## What was broken

| # | Defect | Was |
|---|--------|-----|
| 1 | `data load --path FILE` unreachable — `<name>` was `required=true` while the summary said "or empty for `--path`" | `missing required argument: <name>` |
| 2 | `data load :fred-md` — `Symbol(name)`, no `:`/separator handling | raw `ArgumentError` → **exit 1 "likely a bug"** |
| 3 | Any dataset typo | same untyped **exit 1** |
| 4 | `--transform` documented (`-t`) + handler-supported but never registered | `unknown option --transform` |
| 5 | `load_data(":pwt")` dropped panel `group`/`time` ids | every panel command failed with `data/missing-column` |
| 6 | REPL's hardcoded dash-only `BUILTIN_DATASETS` (5 of 11) | `data use :fred_md` rejected — the spelling `data list` prints |
| 7 | No `expanduser` anywhere | REPL `data use ~/x.csv` → "file not found" (the REPL has no shell) |
| 8 | `data describe`: `n=fill(summary.n, n_vars)`, but `summary.n` is already a per-variable vector | the whole vector nested into every cell |
| 9 | Default output paths from a `:name` source | files literally named `:fred-md_clean.csv` |
| 10 | `data list` | advertised 5 of 11 loadable datasets |

## The fix

One source of truth in `src/io.jl`:

- **`EXAMPLE_DATASETS`** — the 11 rectangular bundled datasets (`:wiot` excluded: it is `IOData` with no `data`/`varnames`, served by the `io` family, and its error hint says so).
- **`parse_dataset_name`** — strips `:`, normalizes `-`→`_`, throws typed `data/unknown-dataset` (exit 3) with a `_nearest` suggestion.
- **`dataset_to_dataframe`** — panels keep `group`/`time`.
- **`dataset_stem`** — no `:` leaks into filenames.
- **`expanduser`** in `load_data`.

`data list`, `data load` and the REPL all derive from it. `session_load_builtin!` is now a one-liner delegating to `session_load_data!(s, ":name")`, so builtins and files take one code path. The REPL's canonical stored form is the underscore symbol (`:fred_md`), matching `data list`/`data load`/MEMs; both spellings are accepted on input.

## Two more bugs, found only once T3 coverage existed

- **`data load mroz|stackloss`** (the `CrossSectionData` sets) called `frequency()`, undefined for cross sections → untyped MethodError, **exit 1**. Now branches on `is_ts`; `--transform`/`--dates` on a cross section is a typed `usage/invalid`.
- **`test cips` read `result.cips`** — a field real MEMs 0.7.0 does not have (it is `cips_statistic`) → **exit 1 on every invocation**. A `Base.getproperty` alias in `test/mocks.jl` masked it, and the existing `_test_cips` testset had no assertions. Alias removed (the mock's property surface must stay a *subset* of real, same lesson as the generic `plot_result` mask in C065a) and an assertion added.

## Gates

- T1/T2 exit 0 — Command Handlers 1284, IO utilities 66, REPL 46
- **T3 1280/1280** (was 1232) + entry points 49/49 — new `data loading (real load_example)` testset covers `--path`, `:`-refs, both separators, typos, every advertised dataset, panel ids end-to-end, `:`-free output paths, scalar `n`, and `~`
- mock-surface PASS · inventory 303 unchanged · `docs --check` OK · gitleaks + semgrep clean

Docs updated: `README.md`, `docs/src/commands/data.md` (full dataset table, `:name` reference section), `docs/src/repl.md`, generated `data.md`.

https://claude.ai/code/session_01A3ZbaiZy1VxQSRf13zNK69