### PR TITLE
fix: close #83, #84, #85 — path guard, mock-alias detection, and the 19 commands it exposed

### DIFF
--- a/docs/src/commands/generated/predict.md
+++ b/docs/src/commands/generated/predict.md
@@ -204,11 +204,14 @@ In-sample fitted values (logit)
 | `--clusters` | — | `String` | `""` | — | Cluster variable column name |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
-| `--marginal-effects` | — | `String` | `""` | — | Compute marginal effects (empty=off) |
-| `--odds-ratio` | — | `String` | `""` | — | Odds ratios (logit) |
-| `--classification-table` | — | `String` | `""` | — | Classification table |
 | `--threshold` | — | `Float64` | `0.5` | — | Classification threshold |
 | `--model` | — | `String` | `""` | — | Load model from a .fmod handle (skip re-estimation) |
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--marginal-effects` | — | Report average marginal effects |
+| `--odds-ratio` | — | Report odds ratios (logit) |
+| `--classification-table` | — | Report the classification table |
 
 **Output tables:** `predict_logit` (In-sample fitted values)
 
@@ -229,8 +232,6 @@ In-sample fitted values (mlogit)
 | `--clusters` | — | `String` | `""` | — | Cluster variable column name |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
-| `--marginal-effects` | — | `String` | `""` | — | Marginal effects |
-| `--base-category` | — | `Int64` | `1` | — | Base category |
 | `--model` | — | `String` | `""` | — | Load model from a .fmod handle (skip re-estimation) |
 
 **Output tables:** `predict_mlogit` (In-sample fitted values)
@@ -252,8 +253,6 @@ In-sample fitted values (ologit)
 | `--clusters` | — | `String` | `""` | — | Cluster variable column name |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
-| `--marginal-effects` | — | `String` | `""` | — | Marginal effects |
-| `--category` | — | `Int64` | `0` | — | Category index |
 | `--model` | — | `String` | `""` | — | Load model from a .fmod handle (skip re-estimation) |
 
 **Output tables:** `predict_ologit` (In-sample fitted values)
@@ -275,8 +274,6 @@ In-sample fitted values (oprobit)
 | `--clusters` | — | `String` | `""` | — | Cluster variable column name |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
-| `--marginal-effects` | — | `String` | `""` | — | Marginal effects |
-| `--category` | — | `Int64` | `0` | — | Category index |
 | `--model` | — | `String` | `""` | — | Load model from a .fmod handle (skip re-estimation) |
 
 **Output tables:** `predict_oprobit` (In-sample fitted values)
@@ -394,10 +391,13 @@ In-sample fitted values (probit)
 | `--clusters` | — | `String` | `""` | — | Cluster variable column name |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
-| `--marginal-effects` | — | `String` | `""` | — | Compute marginal effects (empty=off) |
-| `--classification-table` | — | `String` | `""` | — | Classification table |
 | `--threshold` | — | `Float64` | `0.5` | — | Classification threshold |
 | `--model` | — | `String` | `""` | — | Load model from a .fmod handle (skip re-estimation) |
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--marginal-effects` | — | Report average marginal effects |
+| `--classification-table` | — | Report the classification table |
 
 **Output tables:** `predict_probit` (In-sample fitted values)
 

--- a/docs/src/commands/ordered-multinomial.md
+++ b/docs/src/commands/ordered-multinomial.md
@@ -12,8 +12,8 @@
 
 | Command | Description |
 |---------|-------------|
-| `predict ologit/oprobit/mlogit` | Predicted probabilities |
-| `residuals ologit/oprobit/mlogit` | Model residuals |
+| `predict ologit/oprobit/mlogit` | Predicted probabilities (one `prob_<category>` column per category) |
+| `residuals ologit/oprobit/mlogit` | Not supported upstream — exits `model/unsupported` (5); use `predict` |
 
 ## Tests
 

--- a/docs/src/commands/ordered-multinomial.md
+++ b/docs/src/commands/ordered-multinomial.md
@@ -13,7 +13,7 @@
 | Command | Description |
 |---------|-------------|
 | `predict ologit/oprobit/mlogit` | Predicted probabilities (one `prob_<category>` column per category) |
-| `residuals ologit/oprobit/mlogit` | Not supported upstream — exits `model/unsupported` (5); use `predict` |
+| `residuals ologit/oprobit/mlogit` | Not supported upstream ([MEMs#507](https://github.com/FriedmanJP/MacroEconometricModels.jl/issues/507)) — exits `model/unsupported` (5); use `predict` |
 
 ## Tests
 

--- a/docs/src/commands/predict_residuals.md
+++ b/docs/src/commands/predict_residuals.md
@@ -112,10 +112,12 @@ Options match those in the corresponding `estimate` command for each model type.
 |------|-------------|
 | `--marginal-effects` | Output average marginal effects instead of fitted probabilities |
 | `--odds-ratio` | Output odds ratio table (logit only) |
-| `--classification-table` | Output confusion matrix |
-| `--threshold` | Classification threshold (default: 0.5, with `--classification-table`) |
+| `--classification-table` | Output classification metrics plus the confusion matrix |
+| `--threshold` | Classification threshold (option, default `0.5`; used with `--classification-table`) |
 
-These flags are mutually exclusive with default fitted-values output.
+`--marginal-effects`, `--odds-ratio` and `--classification-table` are boolean flags —
+pass them bare, without a value. They are mutually exclusive with the default
+fitted-values output. `--threshold` takes a value.
 
 ### Panel Regression Models (preg, piv, plogit, pprobit)
 
@@ -135,4 +137,10 @@ For `piv`, also requires `--endog` and `--instruments`.
 | `--dep` | | String | (1st col) | Dependent variable column name |
 | `--cov-type` | | String | `hc1` | Covariance type |
 
-`predict ologit`, `predict oprobit`, and `predict mlogit` return predicted category probabilities. `predict mlogit` supports `--base-category` to control the reference level.
+`predict ologit`, `predict oprobit`, and `predict mlogit` return one predicted-probability
+column per category (`prob_<category>`), plus an `observation` index.
+
+`residuals ologit`, `residuals oprobit` and `residuals mlogit` exit with
+`model/unsupported` (exit 5): MacroEconometricModels 0.7.0 defines no `residuals` method
+for ordered or multinomial models, and there is no single standard residual definition
+for them. Use `predict` for the per-category probabilities instead.

--- a/docs/src/commands/predict_residuals.md
+++ b/docs/src/commands/predict_residuals.md
@@ -144,3 +144,7 @@ column per category (`prob_<category>`), plus an `observation` index.
 `model/unsupported` (exit 5): MacroEconometricModels 0.7.0 defines no `residuals` method
 for ordered or multinomial models, and there is no single standard residual definition
 for them. Use `predict` for the per-category probabilities instead.
+
+This is tracked upstream as
+[MacroEconometricModels.jl#507](https://github.com/FriedmanJP/MacroEconometricModels.jl/issues/507);
+the leaves will be enabled once it ships.

--- a/src/commands/dsge.jl
+++ b/src/commands/dsge.jl
@@ -1208,16 +1208,16 @@ function _dsge_bayes_irf(; model::String, data::String="", params::String="",
 
     _maybe_plot(irf_result; plot=plot, plot_save=plot_save)
 
-    n_h = size(irf_result.mean, 1)
-    ns = size(irf_result.mean, 3)
+    n_h = size(irf_result.point_estimate, 1)
+    ns = size(irf_result.point_estimate, 3)
     varnames = irf_result.variables
     for si in 1:ns
         shock_name = si <= length(irf_result.shocks) ? irf_result.shocks[si] : "shock_$si"
         irf_df = DataFrame()
         irf_df.horizon = 0:(n_h - 1)
         for (vi, vname) in enumerate(varnames)
-            vi > size(irf_result.mean, 2) && break
-            irf_df[!, vname] = irf_result.mean[:, vi, si]
+            vi > size(irf_result.point_estimate, 2) && break
+            irf_df[!, vname] = irf_result.point_estimate[:, vi, si]
         end
         output_result(irf_df; format=Symbol(format),
                       output=_per_var_output_path(output, shock_name),
@@ -1249,9 +1249,9 @@ function _dsge_bayes_fevd(; model::String, data::String="", params::String="",
 
     _maybe_plot(fevd_result; plot=plot, plot_save=plot_save)
 
-    n_v = size(fevd_result.mean, 2)
-    ns = size(fevd_result.mean, 3)
-    n_h = size(fevd_result.mean, 1)
+    n_v = size(fevd_result.point_estimate, 2)
+    ns = size(fevd_result.point_estimate, 3)
+    n_h = size(fevd_result.point_estimate, 1)
     varnames = fevd_result.variables
     for vi in 1:min(n_v, length(varnames))
         vname = varnames[vi]
@@ -1259,7 +1259,7 @@ function _dsge_bayes_fevd(; model::String, data::String="", params::String="",
         fevd_df.horizon = 1:n_h
         for si in 1:ns
             shock_name = si <= length(fevd_result.shocks) ? fevd_result.shocks[si] : "shock_$si"
-            fevd_df[!, shock_name] = fevd_result.mean[:, vi, si]
+            fevd_df[!, shock_name] = fevd_result.point_estimate[:, vi, si]
         end
         output_result(fevd_df; format=Symbol(format),
                       output=_per_var_output_path(output, vname),

--- a/src/commands/estimate.jl
+++ b/src/commands/estimate.jl
@@ -2274,12 +2274,12 @@ function _estimate_favar(; data::String, factors=nothing, lags::Int=2,
     favar, Y, varnames = _load_and_estimate_favar(data, factors, lags, key_vars, method, draws)
 
     if favar isa MacroEconometricModels.BayesianFAVAR
-        _status("Bayesian FAVAR: $(favar.n_factors) factors, $(favar.n_key) key vars, $(favar.n_draws) draws")
+        _status("Bayesian FAVAR: $(favar.n_factors) factors, $(favar.n_key) key vars, $(size(favar.B_draws, 3)) draws")
         pairs = Pair{String,Any}[
             "Factors" => favar.n_factors,
             "Key variables" => favar.n_key,
             "Lags" => favar.p,
-            "MCMC draws" => favar.n_draws,
+            "MCMC draws" => size(favar.B_draws, 3),
         ]
         output_kv(pairs; format=format, output=output, title="Bayesian FAVAR")
         return favar
@@ -2713,7 +2713,7 @@ function _estimate_plogit(; data::String, dep::String="", indep::String="",
         "AIC"             => round(model.aic; digits=4),
         "BIC"             => round(model.bic; digits=4),
         "Converged"       => model.converged,
-        "N obs"           => model.nobs,
+        "N obs"           => model.n_obs,
         "N groups"        => model.n_groups,
     ]
     output_kv(pairs; format=format, title="Model Statistics")
@@ -2745,7 +2745,7 @@ function _estimate_pprobit(; data::String, dep::String="", indep::String="",
         "AIC"             => round(model.aic; digits=4),
         "BIC"             => round(model.bic; digits=4),
         "Converged"       => model.converged,
-        "N obs"           => model.nobs,
+        "N obs"           => model.n_obs,
         "N groups"        => model.n_groups,
     ]
     output_kv(pairs; format=format, title="Model Statistics")

--- a/src/commands/fevd.jl
+++ b/src/commands/fevd.jl
@@ -310,7 +310,9 @@ function _fevd_bvar(; data::String="", lags::Int=4, horizons::Int=20,
 
     _maybe_plot(bfevd; plot=plot, plot_save=plot_save)
 
-    _output_fevd_tables(bfevd.mean, varnames, horizons;
+    # BayesianFEVD.point_estimate is (horizon, variable, shock); the shared renderer
+    # indexes [variable, shock, horizon] like the frequentist FEVD array.
+    _output_fevd_tables(permutedims(bfevd.point_estimate, (2, 3, 1)), varnames, horizons;
                         id=id, title_prefix="Bayesian FEVD", format=format, output=output)
 end
 

--- a/src/commands/fitted.jl
+++ b/src/commands/fitted.jl
@@ -335,15 +335,35 @@ function _predict_logit(; data::String="", dep::String="", cov_type::String="hc1
                       title="Average Marginal Effects (Logit)")
     elseif odds_ratio
         or = MacroEconometricModels.odds_ratio(model)
-        or_df = DataFrame(Variable=or.varnames, Odds_Ratio=round.(or.odds_ratio; digits=6),
+        or_df = DataFrame(Variable=or.varnames, Odds_Ratio=round.(or.or; digits=6),
             CI_Lower=round.(or.ci_lower; digits=6), CI_Upper=round.(or.ci_upper; digits=6))
         output_result(or_df; format=Symbol(format), output=output,
                       title="Odds Ratios (Logit)")
     elseif classification_table
         ct = MacroEconometricModels.classification_table(model; threshold=threshold)
         _status("Classification Table (threshold=$threshold):")
-        for (k, v) in sort(collect(ct))
-            _status("  $k: $v")
+        # Sort by KEY: the dict mixes scalars with a `confusion` matrix, so sorting
+        # the pairs themselves compares a Matrix against a Float (exit 1).
+        scalars = Pair{String,Any}[]
+        confusion = nothing
+        for k in sort(collect(keys(ct)))
+            v = ct[k]
+            if v isa AbstractMatrix
+                confusion = v
+            else
+                push!(scalars, k => v isa AbstractFloat ? round(v; digits=6) : v)
+            end
+        end
+        output_kv(scalars; format=format, output=output,
+                  title="Classification Metrics (threshold=$threshold)")
+        if confusion !== nothing
+            conf_df = DataFrame(confusion, ["predicted_$j" for j in 0:size(confusion, 2) - 1];
+                                makeunique=true)
+            insertcols!(conf_df, 1, :actual => ["actual_$i" for i in 0:size(confusion, 1) - 1];
+                        makeunique=true)
+            output_result(conf_df; format=Symbol(format),
+                          output=_per_var_output_path(output, "confusion"),
+                          title="Confusion Matrix")
         end
     else
         _status("Logit Fitted Probabilities: $dep_name")
@@ -383,8 +403,28 @@ function _predict_probit(; data::String="", dep::String="", cov_type::String="hc
     elseif classification_table
         ct = MacroEconometricModels.classification_table(model; threshold=threshold)
         _status("Classification Table (threshold=$threshold):")
-        for (k, v) in sort(collect(ct))
-            _status("  $k: $v")
+        # Sort by KEY: the dict mixes scalars with a `confusion` matrix, so sorting
+        # the pairs themselves compares a Matrix against a Float (exit 1).
+        scalars = Pair{String,Any}[]
+        confusion = nothing
+        for k in sort(collect(keys(ct)))
+            v = ct[k]
+            if v isa AbstractMatrix
+                confusion = v
+            else
+                push!(scalars, k => v isa AbstractFloat ? round(v; digits=6) : v)
+            end
+        end
+        output_kv(scalars; format=format, output=output,
+                  title="Classification Metrics (threshold=$threshold)")
+        if confusion !== nothing
+            conf_df = DataFrame(confusion, ["predicted_$j" for j in 0:size(confusion, 2) - 1];
+                                makeunique=true)
+            insertcols!(conf_df, 1, :actual => ["actual_$i" for i in 0:size(confusion, 1) - 1];
+                        makeunique=true)
+            output_result(conf_df; format=Symbol(format),
+                          output=_per_var_output_path(output, "confusion"),
+                          title="Confusion Matrix")
         end
     else
         _status("Probit Fitted Probabilities: $dep_name")
@@ -485,6 +525,29 @@ end
 
 # ── Ordered/Multinomial Predict ─────────────────────────
 
+"""
+    _choice_prob_table(probs, categories) → DataFrame
+
+Tidy per-category predicted probabilities.
+
+`predict` on an ordered/multinomial model returns an `n x n_categories` matrix, not a
+vector — feeding it straight to `DataFrame` raised "adding AbstractArray other than
+AbstractVector as a column" (exit 1) on every call (#85).
+"""
+function _choice_prob_table(probs::AbstractMatrix, categories)
+    df = DataFrame(observation=1:size(probs, 1))
+    labels = length(categories) == size(probs, 2) ? string.(categories) :
+             string.(1:size(probs, 2))
+    for (j, lab) in enumerate(labels)
+        df[!, "prob_$lab"] = round.(probs[:, j]; digits=6)
+    end
+    return df
+end
+
+# A univariate result still renders as a single fitted-probability column.
+_choice_prob_table(probs::AbstractVector, categories) =
+    DataFrame(observation=1:length(probs), fitted_prob=round.(probs; digits=6))
+
 function _predict_ologit(; data::String="", dep::String="", cov_type::String="hc1",
                           clusters::String="",
                           output::String="", format::String="table")
@@ -498,7 +561,7 @@ function _predict_ologit(; data::String="", dep::String="", cov_type::String="hc
     _status()
 
     fitted = predict(model)
-    pred_df = DataFrame(observation=1:length(fitted), fitted_prob=round.(fitted; digits=6))
+    pred_df = _choice_prob_table(fitted, model.categories)
     output_result(pred_df; format=Symbol(format), output=output,
                   title="Ordered Logit Predicted Probabilities")
 end
@@ -516,23 +579,25 @@ function _predict_oprobit(; data::String="", dep::String="", cov_type::String="h
     _status()
 
     fitted = predict(model)
-    pred_df = DataFrame(observation=1:length(fitted), fitted_prob=round.(fitted; digits=6))
+    pred_df = _choice_prob_table(fitted, model.categories)
     output_result(pred_df; format=Symbol(format), output=output,
                   title="Ordered Probit Predicted Probabilities")
 end
 
 function _predict_mlogit(; data::String="", dep::String="", cov_type::String="ols",
+                          clusters::String="",
                           output::String="", format::String="table")
     y, X, xcols = _load_reg_data(data, dep)
+    cl = _load_clusters(data, clusters)
     dep_name = isempty(dep) ? variable_names(load_data(data))[1] : dep
 
-    model = estimate_mlogit(y, X; cov_type=Symbol(cov_type), varnames=xcols)
+    model = estimate_mlogit(y, X; cov_type=Symbol(cov_type), varnames=xcols, clusters=cl)
 
     _status("Multinomial Logit Predicted Probabilities: $dep_name")
     _status()
 
     fitted = predict(model)
-    pred_df = DataFrame(observation=1:length(fitted), fitted_prob=round.(fitted; digits=6))
+    pred_df = _choice_prob_table(fitted, model.categories)
     output_result(pred_df; format=Symbol(format), output=output,
                   title="Multinomial Logit Predicted Probabilities")
 end
@@ -976,6 +1041,19 @@ end
 
 # ── Ordered/Multinomial Residuals ───────────────────────
 
+"""
+    _unsupported_residuals(label, leaf)
+
+Ordered/multinomial choice models have no `residuals` method in MEMs 0.7.0, and there
+is no single standard residual definition for them (the test mock used to invent
+`y - fitted[:, 1]`, which is not a recognised statistic). Fail with a typed error
+rather than fabricate one — `predict` gives the per-category probabilities.
+"""
+_unsupported_residuals(label::String, leaf::String) =
+    throw(CliError("model/unsupported",
+        "$label residuals are not defined upstream (MEMs 0.7.0 has no residuals method)";
+        hint="use 'friedman predict $leaf' for per-category predicted probabilities"))
+
 function _residuals_ologit(; data::String="", dep::String="", cov_type::String="hc1",
                             clusters::String="",
                             output::String="", format::String="table")
@@ -988,10 +1066,7 @@ function _residuals_ologit(; data::String="", dep::String="", cov_type::String="
     _status("Ordered Logit Residuals: $dep_name")
     _status()
 
-    resid = residuals(model)
-    res_df = DataFrame(observation=1:length(resid), residual=round.(resid; digits=6))
-    output_result(res_df; format=Symbol(format), output=output,
-                  title="Ordered Logit Residuals")
+    _unsupported_residuals("Ordered Logit", "ologit")
 end
 
 function _residuals_oprobit(; data::String="", dep::String="", cov_type::String="hc1",
@@ -1006,10 +1081,7 @@ function _residuals_oprobit(; data::String="", dep::String="", cov_type::String=
     _status("Ordered Probit Residuals: $dep_name")
     _status()
 
-    resid = residuals(model)
-    res_df = DataFrame(observation=1:length(resid), residual=round.(resid; digits=6))
-    output_result(res_df; format=Symbol(format), output=output,
-                  title="Ordered Probit Residuals")
+    _unsupported_residuals("Ordered Probit", "oprobit")
 end
 
 function _residuals_mlogit(; data::String="", dep::String="", cov_type::String="ols",
@@ -1023,10 +1095,7 @@ function _residuals_mlogit(; data::String="", dep::String="", cov_type::String="
     _status("Multinomial Logit Residuals: $dep_name")
     _status()
 
-    resid = residuals(model)
-    res_df = DataFrame(observation=1:length(resid), residual=round.(resid; digits=6))
-    output_result(res_df; format=Symbol(format), output=output,
-                  title="Multinomial Logit Residuals")
+    _unsupported_residuals("Multinomial Logit", "mlogit")
 end
 
 
@@ -1053,20 +1122,34 @@ function _fitted_base_options(; include_lags=true, include_column=false, include
 end
 
 # Extra option sets for discrete choice / special leaves
+# The handlers take `marginal_effects`/`odds_ratio`/`classification_table` as `Bool`,
+# so these MUST be flags. Declaring them as String options made the default `""`
+# fail Bool conversion on every call ("non-boolean (String) used in boolean
+# context" -> exit 1), breaking predict logit|probit|ologit|oprobit|mlogit
+# outright; none had T3 coverage (#85).
 const _LOGIT_EXTRA = [
-    OptionSpec(name="marginal-effects", type=String, default="", description="Compute marginal effects (empty=off)"),
-    OptionSpec(name="odds-ratio", type=String, default="", description="Odds ratios (logit)"),
-    OptionSpec(name="classification-table", type=String, default="", description="Classification table"),
     OptionSpec(name="threshold", type=Float64, default=0.5, description="Classification threshold"),
 ]
-const _ORDERED_EXTRA = [
-    OptionSpec(name="marginal-effects", type=String, default="", description="Marginal effects"),
-    OptionSpec(name="category", type=Int, default=0, description="Category index"),
+const _LOGIT_EXTRA_FLAGS = [
+    FlagSpec(name="marginal-effects", description="Report average marginal effects"),
+    FlagSpec(name="odds-ratio", description="Report odds ratios (logit)"),
+    FlagSpec(name="classification-table", description="Report the classification table"),
 ]
-const _MLOGIT_EXTRA = [
-    OptionSpec(name="marginal-effects", type=String, default="", description="Marginal effects"),
-    OptionSpec(name="base-category", type=Int, default=1, description="Base category"),
-]
+# NOTE: no extras for the ordered/multinomial leaves. `_predict_ologit`,
+# `_predict_oprobit` and `_predict_mlogit` accept no `marginal_effects`,
+# `category` or `base_category` kwargs, so declaring them produced a
+# MethodError -> exit 1 on every call. Add the options back only together with
+# handler support.
+const _ORDERED_EXTRA = OptionSpec[]
+const _MLOGIT_EXTRA = OptionSpec[]
+
+"""Flags for a fitted leaf — only `predict` exposes the discrete-choice reports."""
+function _flags_for_kind(kind::Symbol, verb::Symbol)
+    verb === :predict || return FlagSpec[]
+    kind === :logit && return _LOGIT_EXTRA_FLAGS
+    kind === :probit && return filter(f -> f.name != "odds-ratio", _LOGIT_EXTRA_FLAGS)
+    return FlagSpec[]
+end
 
 # kind => (handler_predict, handler_residuals, opts_builder_symbol)
 const FITTED_MODEL_KINDS = [
@@ -1118,7 +1201,7 @@ function _opts_for_kind(kind::Symbol, verb::Symbol)
     elseif kind === :logit
         return [REG_OPTIONS...; (verb === :predict ? _LOGIT_EXTRA : OptionSpec[])]
     elseif kind === :probit
-        return [REG_OPTIONS...; (verb === :predict ? filter(o -> o.name != "odds-ratio", _LOGIT_EXTRA) : OptionSpec[])]
+        return [REG_OPTIONS...; (verb === :predict ? _LOGIT_EXTRA : OptionSpec[])]
     elseif kind === :ologit || kind === :oprobit
         return [REG_OPTIONS...; (verb === :predict ? _ORDERED_EXTRA : OptionSpec[])]
     elseif kind === :mlogit
@@ -1167,7 +1250,7 @@ function _specs_for_verb(verb::Symbol, title_prefix::String)
             summary="$title_prefix ($(m.name))",
             args=_fitted_data_arg(),
             options=_opts_for_kind(m.kind, verb),
-            flags=FlagSpec[],
+            flags=_flags_for_kind(m.kind, verb),
             tables=[TableSpec(name=Symbol("$(path0)_$tbl"), description=title_prefix)],
             category=path0,
             aliases=aliases,

--- a/src/commands/fitted.jl
+++ b/src/commands/fitted.jl
@@ -1048,6 +1048,12 @@ Ordered/multinomial choice models have no `residuals` method in MEMs 0.7.0, and 
 is no single standard residual definition for them (the test mock used to invent
 `y - fitted[:, 1]`, which is not a recognised statistic). Fail with a typed error
 rather than fabricate one — `predict` gives the per-category probabilities.
+
+Filed upstream as MacroEconometricModels.jl#507 (which also asks them to settle the
+return shape: an `n x K` response-residual matrix vs a length-`n` generalised
+residual). Re-enabling these leaves is gated on that: CLI issue #87. If upstream
+declines, remove the three leaves at v1.0 (C055) instead of shipping leaves that
+can only error.
 """
 _unsupported_residuals(label::String, leaf::String) =
     throw(CliError("model/unsupported",

--- a/src/commands/hd.jl
+++ b/src/commands/hd.jl
@@ -269,13 +269,13 @@ function _hd_bvar(; data::String="", lags::Int=4, id::String="cholesky",
     _status_report(() -> report(bhd))
     _maybe_plot(bhd; plot=plot, plot_save=plot_save)
 
-    mean_contrib = bhd.mean
+    mean_contrib = bhd.point_estimate
     T_eff = size(mean_contrib, 1)
 
     _output_hd_tables((vi, si) -> mean_contrib[:, vi, si], varnames, T_eff;
                       id=id, title_prefix="Bayesian HD",
                       format=format, output=output,
-                      initial=bhd.initial_mean)
+                      initial=bhd.initial_point_estimate)
 end
 
 # ── LP HD ────────────────────────────────────────────────

--- a/src/commands/nowcast.jl
+++ b/src/commands/nowcast.jl
@@ -220,8 +220,10 @@ function _nowcast_news(; data_new::String="", data_old::String="",
                         target_period::Int=0, target_var::Int=0,
                         output::String="", format::String="table",
                         plot::Bool=false, plot_save::String="")
-    isempty(data_new) && error("--data-new is required")
-    isempty(data_old) && error("--data-old is required")
+    isempty(data_new) && throw(CliError("usage/missing", "--data-new is required";
+        hint="path to the newer data vintage"))
+    isempty(data_old) && throw(CliError("usage/missing", "--data-old is required";
+        hint="path to the older data vintage"))
 
     Y_new, varnames_new = load_multivariate_data(data_new)
     Y_old, _ = load_multivariate_data(data_old)
@@ -240,12 +242,24 @@ function _nowcast_news(; data_new::String="", data_old::String="",
     elseif method == "bvar"
         nowcast_bvar(Y_old, nM, nQ; lags=lags)
     else
-        error("unknown nowcast method for news: $method (expected dfm|bvar)")
+        throw(CliError("usage/invalid",
+            "unknown nowcast method for news: $method"; hint="expected dfm|bvar"))
     end
 
     tp = target_period > 0 ? target_period : T_new
     tv = target_var > 0 ? target_var : size(Y_new, 2)
-    news = nowcast_news(Y_new, Y_old, model, tp; target_var=tv)
+    # The two vintages must be the SAME shape — a vintage differs by which cells are
+    # filled in, not by row count. Upstream signals a mismatch with a bare
+    # ArgumentError, which would exit 1 rather than flag the user's input.
+    news = try
+        nowcast_news(Y_new, Y_old, model, tp; target_var=tv)
+    catch e
+        e isa ArgumentError && throw(CliError("data/shape",
+            "the two vintages must have the same dimensions";
+            hint="new is $(size(Y_new)), old is $(size(Y_old)); a newer vintage fills in " *
+                 "missing cells rather than adding rows"))
+        rethrow()
+    end
 
     _maybe_plot(news; plot=plot, plot_save=plot_save)
 

--- a/src/commands/shared.jl
+++ b/src/commands/shared.jl
@@ -1054,7 +1054,9 @@ function _load_and_estimate_favar(data::String, factors, lags::Int,
             end
         end
     end
-    isempty(key_indices) && error("--key-vars is required for FAVAR (comma-separated column names or indices)")
+    isempty(key_indices) && throw(CliError("usage/missing",
+        "--key-vars is required for FAVAR";
+        hint="comma-separated column names or indices, e.g. --key-vars y,x"))
 
     # Auto-select factors if not specified
     r = if factors === nothing

--- a/src/commands/test.jl
+++ b/src/commands/test.jl
@@ -2855,8 +2855,8 @@ function _test_factor_break(; data::String, factors::Int=2,
         "p-value" => round(result.pvalue; digits=4),
         "Break date (index)" => result.break_date,
         "Method" => result.method,
-        "Factors" => result.r,
-        "Units" => result.n_units,
+        "Factors" => result.n_factors,
+        "Units" => result.n_vars,
     ]
     output_kv(pairs; format=format, output=output, title="Factor Break Test")
 
@@ -2963,16 +2963,16 @@ function _test_dfgls(; data::String, column::Int=1,
     result = dfgls_test(y; lags=lags_arg, kw...)
 
     pairs = Pair{String,Any}[
-        "DF-GLS tau statistic" => round(result.tau_statistic; digits=4),
+        "DF-GLS tau statistic" => round(result.statistic; digits=4),
         "PT statistic" => round(result.pt_statistic; digits=4),
         "p-value" => round(result.pvalue; digits=4),
         "Lags" => result.lags,
         "Observations" => result.nobs,
     ]
 
-    # Add M-GLS statistics if available
-    for (k, v) in result.mgls_statistics
-        push!(pairs, "M-GLS $k" => round(v; digits=4))
+    # M-GLS statistics are separate fields upstream, not a collection.
+    for k in (:MZa, :MZt, :MSB, :MPT)
+        push!(pairs, "M-GLS $k" => round(getfield(result, k); digits=4))
     end
 
     output_kv(pairs; format=format, output=output, title="DF-GLS Test: $vname")
@@ -3009,8 +3009,8 @@ function _test_lm_unitroot(; data::String, column::Int=1,
         "Observations" => result.nobs,
     ]
 
-    if !isnothing(result.break_indices)
-        push!(pairs, "Break indices" => join(result.break_indices, ", "))
+    if !isnothing(result.break_dates)
+        push!(pairs, "Break indices" => join(result.break_dates, ", "))
         push!(pairs, "Break fractions" => join(round.(result.break_fractions; digits=4), ", "))
     end
 
@@ -3043,10 +3043,10 @@ function _test_adf_2break(; data::String, column::Int=1,
     pairs = Pair{String,Any}[
         "Test statistic" => round(result.statistic; digits=4),
         "p-value" => round(result.pvalue; digits=4),
-        "Break 1 index" => result.break_index1,
-        "Break 1 fraction" => round(result.break_fraction1; digits=4),
-        "Break 2 index" => result.break_index2,
-        "Break 2 fraction" => round(result.break_fraction2; digits=4),
+        "Break 1 index" => result.break1,
+        "Break 1 fraction" => round(result.break1_fraction; digits=4),
+        "Break 2 index" => result.break2,
+        "Break 2 fraction" => round(result.break2_fraction; digits=4),
         "Lags" => result.lags,
         "Observations" => result.nobs,
     ]
@@ -3058,7 +3058,7 @@ function _test_adf_2break(; data::String, column::Int=1,
         "Cannot reject H0 (unit root) at 5% -- series appears non-stationary")
 
     _status()
-    _status("Estimated structural breaks at observations $(result.break_index1) and $(result.break_index2)")
+    _status("Estimated structural breaks at observations $(result.break1) and $(result.break2)")
 end
 
 # ── Gregory-Hansen Cointegration Test ───────────────
@@ -3077,18 +3077,27 @@ function _test_gregory_hansen(; data::String, model::String="C",
 
     kw = Dict{Symbol,Any}(:model => model_sym, :trim => trim)
     !isnothing(max_lags) && (kw[:max_lags] = max_lags)
-    result = gregory_hansen_test(Y; lags=lags_arg, kw...)
+    # Cointegration needs a dependent + at least one regressor; upstream signals a
+    # one-column matrix with a bare ArgumentError, which would exit 1 (#81 class).
+    result = try
+        gregory_hansen_test(Y; lags=lags_arg, kw...)
+    catch e
+        e isa ArgumentError && throw(CliError("data/shape",
+            "gregory-hansen needs at least 2 columns (dependent + regressor)";
+            hint="got $(length(varnames)): $(join(varnames, ", "))"))
+        rethrow()
+    end
 
     pairs = Pair{String,Any}[
         "ADF* statistic" => round(result.adf_statistic; digits=4),
         "ADF* p-value" => round(result.adf_pvalue; digits=4),
-        "ADF* break index" => result.adf_break_index,
+        "ADF* break index" => result.adf_break,
         "Zt* statistic" => round(result.zt_statistic; digits=4),
         "Zt* p-value" => round(result.zt_pvalue; digits=4),
-        "Zt* break index" => result.zt_break_index,
+        "Zt* break index" => result.zt_break,
         "Za* statistic" => round(result.za_statistic; digits=4),
         "Za* p-value" => round(result.za_pvalue; digits=4),
-        "Za* break index" => result.za_break_index,
+        "Za* break index" => result.za_break,
         "Model" => result.model,
         "Observations" => result.nobs,
     ]
@@ -3101,7 +3110,7 @@ function _test_gregory_hansen(; data::String, model::String="C",
         "Cannot reject H0: no cointegration with structural break")
 
     _status()
-    _status("Estimated break at observation $(result.adf_break_index) (ADF* criterion)")
+    _status("Estimated break at observation $(result.adf_break) (ADF* criterion)")
 end
 
 # ── VIF (Variance Inflation Factor) ─────────────────
@@ -3347,14 +3356,18 @@ function _test_durbin_watson(; data::String, column::Int=1,
 
     result = durbin_watson_test(y)
 
+    # DurbinWatsonResult is (statistic, pvalue, nobs) — real MEMs exposes no
+    # Savin-White dL/dU bounds or decision string, so report the p-value instead.
     pairs = Pair{String,Any}[
         "DW statistic" => round(result.statistic; digits=4),
-        "Lower bound (dL)" => round(result.lower_bound; digits=4),
-        "Upper bound (dU)" => round(result.upper_bound; digits=4),
-        "Decision" => result.decision,
+        "p-value" => round(result.pvalue; digits=4),
         "Observations" => result.nobs,
     ]
     output_kv(pairs; format=format, output=output, title="Durbin-Watson Test: $vname")
+
+    interpret_test_result(result.pvalue,
+        "Reject H0: residuals are autocorrelated",
+        "Cannot reject H0: no first-order autocorrelation")
 end
 
 # ── Discrete Choice Tests ────────────────────────────

--- a/src/io.jl
+++ b/src/io.jl
@@ -93,31 +93,62 @@ end
 # ── Path Validation ──────────────────────────────────────
 
 """
-    _validate_input_path(path) → String
+    _data_root() → String
 
-Validate that an input file path does not contain path traversal sequences (`..`).
-Returns the path unchanged if valid; throws on suspicious paths.
+Directory that file access is confined to, from `FRIEDMAN_DATA_ROOT`; empty when unset.
+
+Confinement is opt-in. The old guard rejected any path whose *string* contained `..`,
+which blocked ordinary relative paths (`../shared/data.csv` — with no workaround in
+the REPL, which has no shell to resolve them) and even absolute paths whose filename
+merely contained two dots, while still permitting any absolute path to anywhere. That
+is not containment. Set `FRIEDMAN_DATA_ROOT` to get real containment; leave it unset
+for normal filesystem access (#83).
 """
-function _validate_input_path(path::String)
-    if contains(path, "..")
-        throw(CliError("data/bad-path", "path traversal ('..') not allowed in file paths: $path"))
-    end
+_data_root() = get(ENV, "FRIEDMAN_DATA_ROOT", "")
+
+"""
+    _resolve_path(path) → String
+
+Expand `~`, make absolute, and normalize away `.`/`..` segments.
+"""
+_resolve_path(path::String) = normpath(abspath(expanduser(path)))
+
+"""
+    _validate_path(path, kind) → String
+
+Confine `path` to `FRIEDMAN_DATA_ROOT` when that is set, comparing *normalized*
+paths so `..` segments are resolved rather than pattern-matched. Returns `path`
+unchanged (callers keep using the string the user gave).
+"""
+function _validate_path(path::String, kind::String)
+    isempty(path) && return path
+    root = _data_root()
+    isempty(root) && return path
+
+    resolved = _resolve_path(path)
+    root_resolved = _resolve_path(root)
+    sep = Base.Filesystem.path_separator
+    inside = resolved == root_resolved ||
+             startswith(resolved, endswith(root_resolved, sep) ? root_resolved : root_resolved * sep)
+    inside || throw(CliError("data/bad-path",
+        "$kind path escapes FRIEDMAN_DATA_ROOT: $path";
+        hint="resolved to $resolved, which is outside $root_resolved"))
     return path
 end
+
+"""
+    _validate_input_path(path) → String
+
+Validate an input file path. See [`_validate_path`](@ref).
+"""
+_validate_input_path(path::String) = _validate_path(path, "input")
 
 """
     _validate_output_path(path) → String
 
-Validate that an output file path does not contain path traversal sequences (`..`).
-Returns the path unchanged if valid; throws on suspicious paths.
+Validate an output file path. See [`_validate_path`](@ref).
 """
-function _validate_output_path(path::String)
-    isempty(path) && return path
-    if contains(path, "..")
-        throw(CliError("data/bad-path", "path traversal ('..') not allowed in output paths: $path"))
-    end
-    return path
-end
+_validate_output_path(path::String) = _validate_path(path, "output")
 
 # ── Example datasets ─────────────────────────────────────
 

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -2762,6 +2762,228 @@ col_index(tbl, name::AbstractString) = findfirst(==(name), table_cols(tbl))
                 end
             end
         end
+
+        @testset "path confinement is opt-in and resolves, not substring-matches (#83)" begin
+            mktempdir() do root
+                inside = joinpath(root, "in.csv")
+                CSV.write(inside, DataFrame(a=randn(30), b=randn(30)))
+                sub = joinpath(root, "sub"); mkpath(sub)
+                weird = joinpath(root, "dotdot..name.csv")
+                CSV.write(weird, DataFrame(a=randn(30), b=randn(30)))
+
+                # Unconfined: a parent-relative path and a '..' filename both load
+                @test run_json(["data", "describe", joinpath(sub, "..", "in.csv")]).code == 0
+                @test run_json(["data", "describe", weird]).code == 0
+
+                # Confined: inside is fine, escaping is data/bad-path (exit 3)
+                withenv("FRIEDMAN_DATA_ROOT" => root) do
+                    @test run_json(["data", "describe", inside]).code == 0
+                    @test run_json(["data", "describe",
+                                    joinpath(root, "..", "etc", "passwd")]).code == 3
+                end
+            end
+        end
+    end
+
+    # ── Commands whose result-field access was masked by mock aliases (#84) ──
+    # Each of these read a field real MEMs does not have and exited 1 on EVERY
+    # invocation. The mock's `getproperty` aliases invented the field, so T1/T2
+    # passed; none had T3 coverage. Keep every one of them covered here.
+    @testset "result-field access on real MEMs (#84 regressions)" begin
+        uni = dgp_ar1(; T=200, seed=5)
+        multi = dgp_var2(; T=200, seed=5)
+
+        @testset "test durbin-watson (statistic/pvalue, no invented bounds)" begin
+            r = run_json(["test", "durbin-watson", uni])
+            assert_envelope_ok(r; label="durbin-watson")
+            _, tbl = first_table(r.doc)
+            @test tbl !== nothing
+            @test metric_value(tbl, "DW statistic") !== nothing
+            @test metric_value(tbl, "p-value") !== nothing
+        end
+
+        @testset "test dfgls (statistic + separate M-GLS fields)" begin
+            r = run_json(["test", "dfgls", uni])
+            assert_envelope_ok(r; label="dfgls")
+            _, tbl = first_table(r.doc)
+            @test tbl !== nothing
+            @test metric_value(tbl, "DF-GLS tau statistic") !== nothing
+            for k in ("M-GLS MZa", "M-GLS MZt", "M-GLS MSB", "M-GLS MPT")
+                @test metric_value(tbl, k) !== nothing
+            end
+        end
+
+        @testset "test adf-2break (break1/break2 + fractions)" begin
+            r = run_json(["test", "adf-2break", uni])
+            assert_envelope_ok(r; label="adf-2break")
+            _, tbl = first_table(r.doc)
+            @test metric_value(tbl, "Break 1 index") !== nothing
+            @test metric_value(tbl, "Break 2 index") !== nothing
+        end
+
+        @testset "test lm-unitroot (breaks/break_dates)" begin
+            r = run_json(["test", "lm-unitroot", uni])
+            assert_envelope_ok(r; label="lm-unitroot")
+            _, tbl = first_table(r.doc)
+            @test metric_value(tbl, "LM statistic") !== nothing
+        end
+
+        @testset "test gregory-hansen (adf_break/zt_break/za_break)" begin
+            r = run_json(["test", "gregory-hansen", multi])
+            assert_envelope_ok(r; label="gregory-hansen")
+            _, tbl = first_table(r.doc)
+            @test metric_value(tbl, "ADF* break index") !== nothing
+            @test metric_value(tbl, "Za* break index") !== nothing
+            # One column is a cointegration shape error (exit 3), not an exit-1 crash
+            @test run_json(["test", "gregory-hansen", uni]).code == 3
+        end
+
+        @testset "test factor-break (n_factors/n_vars)" begin
+            r = run_json(["test", "factor-break", multi, "--factors", "1"])
+            assert_envelope_ok(r; label="factor-break")
+            _, tbl = first_table(r.doc)
+            @test metric_value(tbl, "Factors") !== nothing
+            @test metric_value(tbl, "Units") !== nothing
+        end
+
+        @testset "fevd bvar (point_estimate, and its (h,var,shock) layout)" begin
+            r = run_json(["fevd", "bvar", multi, "--lags", "1", "--horizons", "4"])
+            assert_envelope_ok(r; label="fevd bvar")
+            _, tbl = first_table(r.doc)
+            @test tbl !== nothing
+            rows = table_rows(tbl)
+            # One row per horizon (a transposed array silently yields n rows instead)
+            @test length(rows) == 4
+            # Variance shares sum to 1 across shocks at every horizon
+            for row in rows
+                vals = Float64.(collect(row)[2:end])
+                @test isapprox(sum(vals), 1.0; atol=1e-6)
+            end
+        end
+
+        @testset "hd bvar (point_estimate + initial_point_estimate)" begin
+            r = run_json(["hd", "bvar", multi, "--lags", "1"])
+            assert_envelope_ok(r; label="hd bvar")
+            _, tbl = first_table(r.doc)
+            @test tbl !== nothing
+            @test !isempty(table_rows(tbl))
+        end
+
+        @testset "estimate favar --method bayesian (draws from B_draws)" begin
+            r = run_json(["estimate", "favar", multi, "--method", "bayesian",
+                          "--factors", "1", "--lags", "1", "--key-vars", "y1"])
+            assert_envelope_ok(r; label="favar bayesian")
+            # Missing --key-vars is a usage error (exit 2), not an untyped exit 1
+            @test run_json(["estimate", "favar", multi, "--method", "bayesian",
+                            "--factors", "1", "--lags", "1"]).code == 2
+        end
+    end
+
+    # ── Families that had no real-MEMs coverage at all (#85) ──
+    @testset "nowcast family (#85: was entirely uncovered)" begin
+        multi = dgp_var2(; T=160, seed=8)
+        # Each leaf has its own option set — dfm takes --factors, bvar only --lags,
+        # bridge takes per-frequency lag counts.
+        for (leaf, extra) in [("dfm", ["--factors", "1", "--lags", "1"]),
+                              ("bvar", ["--lags", "2"]),
+                              ("bridge", ["--lag-m", "1", "--lag-q", "1", "--lag-y", "1"])]
+            @testset "nowcast $leaf" begin
+                r = run_json(vcat(["nowcast", leaf, multi], extra))
+                assert_envelope_ok(r; label="nowcast $leaf")
+            end
+        end
+        @testset "nowcast forecast" begin
+            r = run_json(["nowcast", "forecast", multi, "--factors", "1",
+                          "--lags", "1", "--horizons", "3"])
+            assert_envelope_ok(r; label="nowcast forecast")
+        end
+        @testset "nowcast news" begin
+            # Same-shape vintages: the old one has the final observation not yet
+            # released (a vintage differs in which cells are filled, not row count).
+            new_df = CSV.read(multi, DataFrame)
+            old_df = copy(new_df)
+            old_df[end, 1] = NaN
+            old_path = tempname() * ".csv"
+            CSV.write(old_path, old_df)
+            r = run_json(["nowcast", "news", "--data-new", multi, "--data-old", old_path,
+                          "--factors", "1", "--lags", "1"])
+            assert_envelope_ok(r; label="nowcast news")
+
+            # A row-count mismatch is the user's input, not an internal bug
+            short_path = tempname() * ".csv"
+            CSV.write(short_path, new_df[1:end-1, :])
+            @test run_json(["nowcast", "news", "--data-new", multi, "--data-old", short_path,
+                            "--factors", "1", "--lags", "1"]).code == 3
+            # Missing a required vintage is a usage error
+            @test run_json(["nowcast", "news", "--data-new", multi]).code == 2
+            rm(old_path; force=true); rm(short_path; force=true)
+        end
+    end
+
+    @testset "predict/residuals sweep (#85: was 1 of 23 leaves, nightly-only)" begin
+        multi = dgp_var2(; T=200, seed=9)
+        uni = dgp_ar1(; T=200, seed=9)
+        reg = dgp_reg(; T=200, seed=9)
+        logit = dgp_logit(; T=300, seed=9)
+        gar = dgp_garch(; T=400, seed=9)
+
+        # (leaf, data, extra args) — one per result-type family, so an accessor rename
+        # upstream cannot slip through on either action.
+        cases = [
+            ("var",    multi, ["--lags", "1"]),
+            ("bvar",   multi, ["--lags", "1"]),
+            ("vecm",   multi, ["--lags", "2", "--rank", "1"]),
+            ("arima",  uni,   ["--column", "1"]),
+            ("reg",    reg,   ["--dep", "y"]),
+            ("logit",  logit, ["--dep", "y"]),
+            ("probit", logit, ["--dep", "y"]),
+            ("garch",  gar,   ["--column", "1"]),
+        ]
+        for (leaf, data, extra) in cases
+            for action in ("predict", "residuals")
+                @testset "$action $leaf" begin
+                    r = run_json(vcat([action, leaf, data], extra))
+                    assert_envelope_ok(r; label="$action $leaf")
+                    _, tbl = first_table(r.doc)
+                    @test tbl !== nothing
+                    @test tbl !== nothing && !isempty(table_rows(tbl))
+                end
+            end
+        end
+
+        # Ordered/multinomial: `predict` returns an n x n_categories probability
+        # matrix (feeding it to DataFrame used to be an exit-1 crash), and MEMs
+        # defines no `residuals` for them, so that must be a typed refusal.
+        ord = tempname() * ".csv"
+        let n = 300
+            Random.seed!(19)
+            CSV.write(ord, DataFrame(y=rand(1:3, n), x1=randn(n), x2=randn(n)))
+        end
+        for leaf in ("ologit", "oprobit", "mlogit")
+            @testset "predict $leaf (per-category probabilities)" begin
+                r = run_json(["predict", leaf, ord, "--dep", "y"])
+                assert_envelope_ok(r; label="predict $leaf")
+                _, tbl = first_table(r.doc)
+                @test tbl !== nothing
+                if tbl !== nothing
+                    cols = table_cols(tbl)
+                    @test count(c -> startswith(c, "prob_"), cols) == 3
+                end
+            end
+            @testset "residuals $leaf → model/unsupported (exit 5)" begin
+                @test run_json(["residuals", leaf, ord, "--dep", "y"]).code == 5
+            end
+        end
+
+        @testset "predict logit reports (flags, not string options)" begin
+            for flag in ("--odds-ratio", "--marginal-effects", "--classification-table")
+                r = run_json(["predict", "logit", logit, "--dep", "y", flag])
+                assert_envelope_ok(r; label="predict logit $flag")
+            end
+            # probit has no odds ratio → unknown option is a usage error
+            @test run_json(["predict", "probit", logit, "--dep", "y", "--odds-ratio"]).code == 2
+        end
+        rm(ord; force=true)
     end
 end
 

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -2137,7 +2137,12 @@ function nowcast(model::AbstractNowcastModel; target_var=nothing)
 end
 
 function nowcast_news(X_new, X_old, model::AbstractNowcastModel, target_period; target_var=size(X_new, 2), groups=nothing)
-    N = size(X_new, 2)
+    # Validate like real (nowcast/news.jl): a vintage differs by which cells are
+    # filled in, not by shape. Without this the CLI's data/shape mapping is untested.
+    T_obs, N = size(X_new)
+    size(X_old) == (T_obs, N) || throw(ArgumentError("X_new and X_old must have same size"))
+    1 <= target_period <= T_obs || throw(ArgumentError("target_period out of range"))
+    1 <= target_var <= N || throw(ArgumentError("target_var out of range"))
     NowcastNews{Float64}(1.0, 1.5, randn(N), 0.1, 0.05,
         isnothing(groups) ? randn(1) : randn(length(unique(groups))),
         ["var$i" for i in 1:N])
@@ -5122,10 +5127,24 @@ function vif(m::RegModel{T}) where T
     vals
 end
 
+# Real returns Dict{String,Any} mixing scalars with a "confusion" MATRIX (rows =
+# actual 0/1, cols = predicted 0/1) — that mix is what made `sort(collect(ct))`
+# compare a Matrix against a Float (#85). The old mock returned scalars only,
+# under invented keys (recall/f1/true_positive/…) that real does not have, so the
+# matrix branch of the renderer was never exercised. Mirror the real key set.
 function classification_table(m::Union{LogitModel,ProbitModel}; threshold=0.5)
-    Dict("accuracy" => 0.85, "precision" => 0.80, "recall" => 0.75,
-         "f1" => 0.77, "true_positive" => 30, "true_negative" => 55,
-         "false_positive" => 8, "false_negative" => 10, "threshold" => threshold)
+    tn, fp, fn, tp = 55.0, 8.0, 10.0, 30.0
+    Dict{String,Any}(
+        "confusion"   => [tn fp; fn tp],
+        "accuracy"    => (tp + tn) / (tp + tn + fp + fn),
+        "sensitivity" => tp / (tp + fn),
+        "specificity" => tn / (tn + fp),
+        "precision"   => tp / (tp + fp),
+        "f1_score"    => 2 * (tp / (tp + fp)) * (tp / (tp + fn)) /
+                             ((tp / (tp + fp)) + (tp / (tp + fn))),
+        "n"           => Int(tp + tn + fp + fn),
+        "threshold"   => threshold,
+    )
 end
 
 export RegModel, LogitModel, ProbitModel, MarginalEffects
@@ -5265,6 +5284,9 @@ end
 
 function gregory_hansen_test(Y::AbstractMatrix{T};
         model=:C, lags=:aic, max_lags=nothing, trim=0.15) where T
+    # Real rejects a single-column matrix (teststat/gregory_hansen.jl) — a
+    # cointegrating regression needs a dependent plus at least one regressor.
+    size(Y, 2) >= 2 || throw(ArgumentError("Need at least 2 columns (dependent + regressor)"))
     n = size(Y, 1)
     bp = div(n, 2)
     cvs = Dict(1 => T(-5.13), 5 => T(-4.61), 10 => T(-4.34))

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -732,11 +732,15 @@ optimize_hyperparameters(Y, p) = MinnesotaHyperparameters(tau=0.2, decay=1.0, la
 
 # StatsAPI-like functions
 coef(m::VARModel) = m.B
-coef(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}) = m.coefficients
+function coef(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel})
+    m isa ARModel && return getfield(m, :phi)
+    m isa MAModel && return getfield(m, :theta)
+    return vcat(getfield(m, :phi), getfield(m, :theta))
+end
 loglikelihood(m::VARModel) = -500.0
-loglikelihood(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}) = m.ll
+loglikelihood(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}) = m.loglik
 stderror(m::GMMModel) = fill(0.1, length(m.theta))
-stderror(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}) = fill(0.01, length(m.coefficients))
+stderror(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}) = fill(0.01, length(coef(m)))
 stderror(m::ARCHModel) = fill(0.01, 2 + m.q)  # mu, omega, alpha...
 stderror(m::GARCHModel) = fill(0.01, 2 + m.q + m.p)  # mu, omega, alpha..., beta...
 stderror(m::EGARCHModel) = fill(0.01, 2 + m.q + m.q + m.p)  # mu, omega, alpha..., gamma..., beta...
@@ -871,15 +875,17 @@ function fevd(model::VARModel, horizon::Int; method=:cholesky, check_func=nothin
 end
 function fevd(chain::MockChains, p::Int, n::Int, horizon::Int;
               data=nothing, quantiles=[0.16, 0.5, 0.84])
-    props = ones(n, n, horizon) / n
-    q = ones(n, n, horizon, length(quantiles)) / n
+    # Real BayesianFEVD.point_estimate is (horizon, variable, shock) — match it, or
+    # the mock hides a transposed render (the layout half of #84's fevd bvar bug).
+    props = ones(horizon, n, n) / n
+    q = ones(horizon, n, n, length(quantiles)) / n
     BayesianFEVD(props, q, Float64.(quantiles))
 end
 function fevd(post::BVARPosterior, horizon::Int;
               quantiles=[0.16, 0.5, 0.84])
     n = post.n
-    props = ones(n, n, horizon) / n
-    q = ones(n, n, horizon, length(quantiles)) / n
+    props = ones(horizon, n, n) / n
+    q = ones(horizon, n, n, length(quantiles)) / n
     BayesianFEVD(props, q, Float64.(quantiles))
 end
 
@@ -4961,8 +4967,8 @@ coef(m::RegModel) = m.beta
 vcov(m::RegModel) = m.vcov_mat
 residuals(m::RegModel) = m.residuals
 predict(m::RegModel) = m.fitted
-stderror(m::RegModel) = [sqrt(m.var_beta[i,i]) for i in 1:size(m.var_beta, 1)]
-nobs(m::RegModel) = m.nobs
+stderror(m::RegModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat, 1)]
+nobs(m::RegModel) = m.n_obs
 loglikelihood(m::RegModel) = m.loglik
 aic(m::RegModel) = m.aic
 bic(m::RegModel) = m.bic
@@ -4974,8 +4980,8 @@ coef(m::LogitModel) = m.beta
 vcov(m::LogitModel) = m.vcov_mat
 residuals(m::LogitModel) = m.residuals
 predict(m::LogitModel) = m.fitted
-stderror(m::LogitModel) = [sqrt(m.var_beta[i,i]) for i in 1:size(m.var_beta, 1)]
-nobs(m::LogitModel) = m.nobs
+stderror(m::LogitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat, 1)]
+nobs(m::LogitModel) = length(m.y)
 loglikelihood(m::LogitModel) = m.loglik
 aic(m::LogitModel) = m.aic
 bic(m::LogitModel) = m.bic
@@ -4987,8 +4993,8 @@ coef(m::ProbitModel) = m.beta
 vcov(m::ProbitModel) = m.vcov_mat
 residuals(m::ProbitModel) = m.residuals
 predict(m::ProbitModel) = m.fitted
-stderror(m::ProbitModel) = [sqrt(m.var_beta[i,i]) for i in 1:size(m.var_beta, 1)]
-nobs(m::ProbitModel) = m.nobs
+stderror(m::ProbitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat, 1)]
+nobs(m::ProbitModel) = length(m.y)
 loglikelihood(m::ProbitModel) = m.loglik
 aic(m::ProbitModel) = m.aic
 bic(m::ProbitModel) = m.bic
@@ -5098,7 +5104,8 @@ function odds_ratio(m::LogitModel{T}; conf_level=0.95) where T
     z_crit = T(1.96)
     ci_lo = exp.(m.beta .- z_crit .* se)
     ci_hi = exp.(m.beta .+ z_crit .* se)
-    (odds_ratio=or, ci_lower=ci_lo, ci_upper=ci_hi, varnames=m.varnames)
+    # Field is `or` upstream (OddsRatio struct) — name it the same here.
+    (or=or, se=se, ci_lower=ci_lo, ci_upper=ci_hi, varnames=m.varnames, conf_level=conf_level)
 end
 
 function vif(m::RegModel{T}) where T
@@ -5613,81 +5620,6 @@ function durbin_watson_test(residuals::AbstractVector{T}) where T
 end
 
 # Field aliases for spectral handler compat (legacy mock names → real fields)
-function Base.getproperty(r::SpectralDensityResult, s::Symbol)
-    s === :spectrum && return getfield(r, :density)
-    s === :frequencies && return getfield(r, :freq)
-    s === :log_spectrum && return log.(max.(getfield(r, :density), eps(eltype(getfield(r, :density)))))
-    s === :kernel && return :none
-    s === :varname && return "y"
-    return getfield(r, s)
-end
-function Base.getproperty(r::CrossSpectrumResult, s::Symbol)
-    s === :frequencies && return getfield(r, :freq)
-    s === :cross_spectrum && return complex.(getfield(r, :co_spectrum), getfield(r, :quad_spectrum))
-    s === :var1 && return "y1"
-    s === :var2 && return "y2"
-    return getfield(r, s)
-end
-function Base.getproperty(r::TransferFunctionResult, s::Symbol)
-    s === :frequencies && return getfield(r, :freq)
-    s === :coherence && return ones(eltype(getfield(r, :gain)), length(getfield(r, :gain)))
-    s === :var_input && return string(getfield(r, :filter))
-    s === :var_output && return "output"
-    s === :nobs && return length(getfield(r, :freq)) * 2
-    return getfield(r, s)
-end
-function Base.getproperty(r::ACFResult, s::Symbol)
-    s === :ci_band && return getfield(r, :ci)
-    s === :conf_level && return 0.95
-    s === :varname && return "y"
-    return getfield(r, s)
-end
-function Base.getproperty(r::FisherTestResult, s::Symbol)
-    s === :dominant_frequency && return getfield(r, :peak_freq)
-    s === :periodogram_values && return Float64[]
-    s === :frequencies && return Float64[]
-    return getfield(r, s)
-end
-function Base.getproperty(r::BartlettWhiteNoiseResult, s::Symbol)
-    s === :lags_tested && return 0
-    s === :individual_stats && return Float64[]
-    s === :individual_pvalues && return Float64[]
-    return getfield(r, s)
-end
-function Base.getproperty(r::BoxPierceResult, s::Symbol)
-    s === :ljung_box && return true
-    return getfield(r, s)
-end
-function Base.getproperty(r::DurbinWatsonResult, s::Symbol)
-    s === :decision && return :inconclusive
-    s === :lower_bound && return 1.5
-    s === :upper_bound && return 2.5
-    return getfield(r, s)
-end
-function Base.getproperty(r::DFGLSResult, s::Symbol)
-    s === :tau_statistic && return getfield(r, :statistic)
-    s === :mgls_statistics && return Dict(:MZa => getfield(r, :MZa), :MZt => getfield(r, :MZt),
-                                          :MSB => getfield(r, :MSB), :MPT => getfield(r, :MPT))
-    return getfield(r, s)
-end
-function Base.getproperty(r::LMUnitRootResult, s::Symbol)
-    s === :break_indices && return getfield(r, :break_dates)
-    return getfield(r, s)
-end
-function Base.getproperty(r::ADF2BreakResult, s::Symbol)
-    s === :break_index1 && return getfield(r, :break1)
-    s === :break_index2 && return getfield(r, :break2)
-    s === :break_fraction1 && return getfield(r, :break1_fraction)
-    s === :break_fraction2 && return getfield(r, :break2_fraction)
-    return getfield(r, s)
-end
-function Base.getproperty(r::GregoryHansenResult, s::Symbol)
-    s === :adf_break_index && return getfield(r, :adf_break)
-    s === :zt_break_index && return getfield(r, :zt_break)
-    s === :za_break_index && return getfield(r, :za_break)
-    s === :critical_values && return getfield(r, :adf_critical_values)
-    return getfield(r, s)
-end
 
 export ACFResult, SpectralDensityResult, CrossSpectrumResult, TransferFunctionResult
 export FisherTestResult, BartlettWhiteNoiseResult, BoxPierceResult, DurbinWatsonResult
@@ -5823,8 +5755,8 @@ vcov(m::PanelLogitModel) = m.vcov_mat
 vcov(m::PanelProbitModel) = m.vcov_mat
 residuals(m::PanelRegModel) = m.residuals
 residuals(m::PanelIVModel) = m.residuals
-residuals(m::PanelLogitModel) = m.residuals
-residuals(m::PanelProbitModel) = m.residuals
+residuals(m::PanelLogitModel) = m.y .- m.fitted
+residuals(m::PanelProbitModel) = m.y .- m.fitted
 predict(m::PanelRegModel) = m.fitted
 predict(m::PanelIVModel) = m.fitted
 predict(m::PanelLogitModel) = m.fitted
@@ -5833,10 +5765,10 @@ stderror(m::PanelRegModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1
 stderror(m::PanelIVModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1)]
 stderror(m::PanelLogitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1)]
 stderror(m::PanelProbitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1)]
-nobs(m::PanelRegModel) = m.nobs
-nobs(m::PanelIVModel) = m.nobs
-nobs(m::PanelLogitModel) = m.nobs
-nobs(m::PanelProbitModel) = m.nobs
+nobs(m::PanelRegModel) = m.n_obs
+nobs(m::PanelIVModel) = m.n_obs
+nobs(m::PanelLogitModel) = m.n_obs
+nobs(m::PanelProbitModel) = m.n_obs
 loglikelihood(m::PanelRegModel) = m.loglik
 loglikelihood(m::PanelLogitModel) = m.loglik
 loglikelihood(m::PanelProbitModel) = m.loglik
@@ -6030,22 +5962,6 @@ predict(m::OrderedProbitModel) = m.fitted[:, 1]
 predict(m::MultinomialLogitModel) = m.fitted[:, 1]
 
 # Compat aliases for handlers still using legacy field names
-function Base.getproperty(m::Union{OrderedLogitModel,OrderedProbitModel}, s::Symbol)
-    s === :thresholds && return getfield(m, :cutpoints)
-    s === :n_categories && return length(getfield(m, :categories))
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :nobs && return length(getfield(m, :y))
-    s === :residuals && return getfield(m, :y) .- getfield(m, :fitted)[:, 1]
-    return getfield(m, s)
-end
-function Base.getproperty(m::MultinomialLogitModel, s::Symbol)
-    s === :n_categories && return length(getfield(m, :categories))
-    s === :base_category && return first(getfield(m, :categories))
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :nobs && return length(getfield(m, :y))
-    s === :residuals && return getfield(m, :y) .- getfield(m, :fitted)[:, 1]
-    return getfield(m, s)
-end
 stderror(m::OrderedLogitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1)]
 stderror(m::OrderedProbitModel) = [sqrt(m.vcov_mat[i,i]) for i in 1:size(m.vcov_mat,1)]
 stderror(m::MultinomialLogitModel) = vcat([[sqrt(m.vcov_mat[i,i,c]) for i in 1:size(m.vcov_mat,1)] for c in 1:size(m.vcov_mat,3)]...)
@@ -6098,7 +6014,7 @@ end
 
 function estimate_mlogit(y::AbstractVector{T}, X::AbstractMatrix{T};
         n_categories::Int=3, base_category::Int=1, cov_type::Symbol=:hc1,
-        varnames=nothing, maxiter::Int=100, tol::Real=1e-8) where T
+        varnames=nothing, clusters=nothing, maxiter::Int=100, tol::Real=1e-8) where T
     n, k = size(X)
     nc = n_categories
     beta = ones(T, k, nc) * T(0.3)
@@ -6180,124 +6096,16 @@ function keeprows(ts, indices::AbstractVector)
     ts
 end
 
-# Compat field aliases (handlers may still use legacy names)
-function Base.getproperty(m::PanelRegModel, s::Symbol)
-    s === :nobs && return getfield(m, :n_obs)
-    s === :within_r2 && return getfield(m, :r2_within)
-    s === :between_r2 && return getfield(m, :r2_between)
-    s === :overall_r2 && return getfield(m, :r2_overall)
-    s === :f_pvalue && return getfield(m, :f_pval)
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :fe_type && return getfield(m, :method)
-    s === :panel && return getfield(m, :data)
-    s === :dof_resid && return getfield(m, :n_obs) - length(getfield(m, :beta))
-    s === :rank && return length(getfield(m, :beta))
-    s === :clusters && return nothing
-    return getfield(m, s)
-end
-function Base.getproperty(m::PanelIVModel, s::Symbol)
-    s === :nobs && return getfield(m, :n_obs)
-    s === :within_r2 && return getfield(m, :r2_within)
-    s === :overall_r2 && return getfield(m, :r2_overall)
-    s === :f_pvalue && return getfield(m, :f_stat)  # no f_pval on real IV; expose f_stat
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :fe_type && return getfield(m, :method)
-    s === :panel && return getfield(m, :data)
-    s === :dof_resid && return getfield(m, :n_obs) - length(getfield(m, :beta))
-    s === :rank && return length(getfield(m, :beta))
-    s === :clusters && return nothing
-    return getfield(m, s)
-end
-function Base.getproperty(m::Union{PanelLogitModel,PanelProbitModel}, s::Symbol)
-    s === :nobs && return getfield(m, :n_obs)
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :fe_type && return getfield(m, :method)
-    s === :panel && return getfield(m, :data)
-    s === :residuals && return getfield(m, :y) .- getfield(m, :fitted)
-    return getfield(m, s)
-end
-function Base.getproperty(m::RegModel, s::Symbol)
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :f_pvalue && return getfield(m, :f_pval)
-    s === :nobs && return length(getfield(m, :y))
-    s === :rank && return length(getfield(m, :beta))
-    s === :dof_resid && return length(getfield(m, :y)) - length(getfield(m, :beta))
-    s === :clusters && return nothing
-    return getfield(m, s)
-end
-function Base.getproperty(m::Union{LogitModel,ProbitModel}, s::Symbol)
-    s === :var_beta && return getfield(m, :vcov_mat)
-    s === :nobs && return length(getfield(m, :y))
-    return getfield(m, s)
-end
-function Base.getproperty(m::BayesianImpulseResponse, s::Symbol)
-    s === :mean && return getfield(m, :point_estimate)
-    return getfield(m, s)
-end
-function Base.getproperty(m::BayesianFEVD, s::Symbol)
-    s === :mean && return getfield(m, :point_estimate)
-    return getfield(m, s)
-end
-function Base.getproperty(m::BayesianHistoricalDecomposition, s::Symbol)
-    s === :mean && return getfield(m, :point_estimate)
-    s === :initial_mean && return getfield(m, :initial_point_estimate)
-    s === :shocks_mean && return getfield(m, :shocks_point_estimate)
-    return getfield(m, s)
-end
-function Base.getproperty(m::LPDiDResult, s::Symbol)
-    s === :se_vec && return getfield(m, :se)
-    s === :nobs_h && return getfield(m, :nobs_per_horizon)
-    s === :pooled_post_result && return getfield(m, :pooled_post)
-    s === :pooled_pre_result && return getfield(m, :pooled_pre)
-    s === :vcov_all && return getfield(m, :vcov)
-    s === :outcome_name && return getfield(m, :outcome_var)
-    s === :treatment_name && return getfield(m, :treatment_var)
-    s === :spec_type && return getfield(m, :specification)
-    s === :pd && return getfield(m, :data)
-    return getfield(m, s)
-end
-function Base.getproperty(m::BVARForecast, s::Symbol)
-    s === :ci_method && return getfield(m, :point_estimate)
-    return getfield(m, s)
-end
-function Base.getproperty(m::BayesianFAVAR, s::Symbol)
-    s === :Y && return getfield(m, :data)
-    s === :factors && return dropdims(mean(getfield(m, :factor_draws); dims=3); dims=3)
-    s === :loadings && return dropdims(mean(getfield(m, :loadings_draws); dims=3); dims=3)
-    s === :n_draws && return size(getfield(m, :B_draws), 3)
-    return getfield(m, s)
-end
-# NOTE: no `cips`/`individual_cadf` aliases here. Real MEMs 0.7.0 exposes only
-# `cips_statistic`/`individual_cadf_stats`; the aliases this mock used to provide
-# hid a handler that read `result.cips` and crashed (exit 1) on real MEMs.
-# Keep the mock's property surface a subset of the real one.
-function Base.getproperty(m::FactorBreakResult, s::Symbol)
-    s === :r && return getfield(m, :n_factors)
-    s === :n_units && return getfield(m, :n_vars)
-    return getfield(m, s)
-end
-function Base.getproperty(m::GeneralizedDynamicFactorModel, s::Symbol)
-    s === :loadings && return dropdims(mean(getfield(m, :loadings_spectral); dims=3); dims=3)
-    return getfield(m, s)
-end
-function Base.getproperty(m::Union{ARModel,MAModel,ARMAModel,ARIMAModel}, s::Symbol)
-    s === :aic_val && return getfield(m, :aic)
-    s === :bic_val && return getfield(m, :bic)
-    s === :ll && return getfield(m, :loglik)
-    s === :sigma && return sqrt(getfield(m, :sigma2))
-    s === :coefficients && begin
-        if m isa ARModel
-            return getfield(m, :phi)
-        elseif m isa MAModel
-            return getfield(m, :theta)
-        elseif m isa ARMAModel
-            return vcat(getfield(m, :phi), getfield(m, :theta))
-        else
-            return vcat(getfield(m, :phi), getfield(m, :theta))
-        end
-    end
-    return getfield(m, s)
-end
+# NOTE: this mock deliberately defines NO `Base.getproperty` compat aliases.
+#
+# Aliases here (`result.cips` → `cips_statistic`, `bfevd.mean` → `point_estimate`,
+# `model.nobs`, `arima.coefficients`, …) invent a property surface real MEMs does
+# not have. Because they are methods rather than fields, `check_mock_surface`'s
+# field-subset test could not see them, so eleven commands shipped reading fields
+# that do not exist and crashed with `FieldError` (exit 1) on real MEMs while
+# T1/T2 stayed green — see #84. `check_mock_surface.jl` now fails the gate on any
+# mock `getproperty` alias that is not a real field. Keep it that way: make the
+# handler use the real accessor instead of teaching the mock a new name.
 
 # --- C039 Phase-4 surface mocks (MEMs 0.6.7 fields ⊆ real) ---
 struct HADSGESpec{T<:AbstractFloat}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2838,9 +2838,46 @@ end
         end
     end
 
-    @testset "load_data path traversal rejection" begin
-        @test_throws CliError load_data("../etc/passwd")
-        @test_throws CliError load_data("data/../../../secret.csv")
+    @testset "path confinement under FRIEDMAN_DATA_ROOT (#83)" begin
+        mktempdir() do root
+            inside = joinpath(root, "ok.csv")
+            CSV.write(inside, DataFrame(a=[1.0, 2.0]))
+            outside = tempname() * ".csv"
+            CSV.write(outside, DataFrame(a=[1.0, 2.0]))
+            mkpath(joinpath(root, "sub"))   # a `..` only resolves through a real directory
+            withenv("FRIEDMAN_DATA_ROOT" => root) do
+                # Inside the root loads, including via a `..` segment resolving back in
+                @test nrow(load_data(inside)) == 2
+                @test nrow(load_data(joinpath(root, "sub", "..", "ok.csv"))) == 2
+                # Escapes are refused on the RESOLVED path, not a substring match
+                @test_throws CliError load_data(outside)
+                @test_throws CliError load_data(joinpath(root, "..", "etc", "passwd"))
+                df = DataFrame(a=[1, 2, 3])
+                @test_throws CliError output_result(df; format=:csv,
+                                                   output=joinpath(root, "..", "bad.csv"))
+                ok_out = joinpath(root, "written.csv")
+                output_result(df; format=:csv, output=ok_out)
+                @test isfile(ok_out)
+            end
+            rm(outside; force=true)
+        end
+    end
+
+    @testset "no false path rejections when unconfined (#83)" begin
+        # Regression: `contains(path, "..")` rejected both of these outright.
+        mktempdir() do dir
+            weird = joinpath(dir, "dotdot..name.csv")   # '..' inside an ordinary filename
+            CSV.write(weird, DataFrame(a=[1.0, 2.0]))
+            sub = joinpath(dir, "sub"); mkpath(sub)
+            withenv("FRIEDMAN_DATA_ROOT" => nothing) do
+                @test nrow(load_data(weird)) == 2
+                @test nrow(load_data(joinpath(sub, "..", "dotdot..name.csv"))) == 2
+                df = DataFrame(a=[1, 2, 3])
+                out = joinpath(sub, "..", "out..1.csv")
+                output_result(df; format=:csv, output=out)
+                @test isfile(out)
+            end
+        end
     end
 
     @testset "load_data expands ~" begin
@@ -2894,11 +2931,6 @@ end
         @test dataset_stem("noext") == "noext"
     end
 
-    @testset "output path traversal rejection" begin
-        df = DataFrame(a=[1,2,3])
-        @test_throws CliError output_result(df; format=:csv, output="../bad.csv")
-        @test_throws CliError output_result(df; format=:csv, output="foo/../../bad.csv")
-    end
 
     @testset "strict format validation (F18/F19)" begin
         df = DataFrame(a=[1.0], b=[2.0])

--- a/test/test_commands.jl
+++ b/test/test_commands.jl
@@ -9611,23 +9611,39 @@ end
             end
         end
 
-        @testset "_residuals_ologit" begin
+        @testset "_residuals_ologit — model/unsupported (no upstream residuals)" begin
             mktempdir() do dir
                 csv = _make_csv(dir; T=100, n=4)
-                out = _capture() do
-                    _residuals_ologit(; data=csv, dep="var1", cov_type="hc1",
-                                       clusters="", output="", format="table")
+                e = try
+                    _capture() do
+                        _residuals_ologit(; data=csv, dep="var1", cov_type="hc1",
+                                           clusters="", output="", format="table")
+                    end
+                    nothing
+                catch err
+                    err
                 end
+                # MEMs 0.7.0 defines no residuals for ordered models; refuse with a
+                # typed error rather than invent a definition (was exit 1).
+                @test e isa CliError
+                @test e.code == "model/unsupported"
             end
         end
 
-        @testset "_residuals_mlogit" begin
+        @testset "_residuals_mlogit — model/unsupported (no upstream residuals)" begin
             mktempdir() do dir
                 csv = _make_csv(dir; T=100, n=4)
-                out = _capture() do
-                    _residuals_mlogit(; data=csv, dep="var1", cov_type="ols",
-                                       output="", format="table")
+                e = try
+                    _capture() do
+                        _residuals_mlogit(; data=csv, dep="var1", cov_type="ols",
+                                           output="", format="table")
+                    end
+                    nothing
+                catch err
+                    err
                 end
+                @test e isa CliError
+                @test e.code == "model/unsupported"
             end
         end
     end

--- a/test/test_commands.jl
+++ b/test/test_commands.jl
@@ -5107,6 +5107,13 @@ end  # VECM handlers
                                  classification_table=true,
                                  format="table", output="")
             end
+            # The dict mixes scalars with a `confusion` MATRIX: the scalars render
+            # as kv and the matrix as its own labelled table. Sorting the pairs
+            # themselves compared a Matrix against a Float and exited 1 (#85).
+            @test contains(out, "accuracy")
+            @test contains(out, "Confusion Matrix")
+            @test contains(out, "predicted_0")
+            @test contains(out, "actual_1")
         end
     end
 
@@ -5146,6 +5153,8 @@ end  # VECM handlers
                                   classification_table=true,
                                   format="table", output="")
             end
+            @test contains(out, "accuracy")
+            @test contains(out, "Confusion Matrix")
         end
     end
 
@@ -6924,14 +6933,17 @@ end  # Data handlers
         end
     end
 
+    # A vintage differs from its predecessor by which cells are FILLED IN, not by
+    # row count — both matrices must be the same shape. These two used to hand the
+    # handler a 105-row new vintage against a 100-row old one and passed only
+    # because the mock accepted anything; real MEMs raises on it.
     @testset "_nowcast_news — basic" begin
         mktempdir() do dir
             csv_old = _make_csv(dir; T=100, n=5, colnames=["m1","m2","m3","m4","q1"])
             csv_new = joinpath(dir, "data_new.csv")
-            # Create new vintage with slightly more data
             data = Dict{String,Vector{Float64}}()
             for name in ["m1","m2","m3","m4","q1"]
-                data[name] = randn(105) .+ 1.0
+                data[name] = randn(100) .+ 1.0
             end
             CSV.write(csv_new, DataFrame(data))
 
@@ -6947,13 +6959,38 @@ end  # Data handlers
         @test_throws Exception _nowcast_news(; data_new="new.csv", data_old="")
     end
 
-    @testset "_nowcast_news — bvar method" begin
+    @testset "_nowcast_news — mismatched vintages are data/shape (#85)" begin
         mktempdir() do dir
             csv_old = _make_csv(dir; T=100, n=5, colnames=["m1","m2","m3","m4","q1"])
             csv_new = joinpath(dir, "data_new.csv")
             data = Dict{String,Vector{Float64}}()
             for name in ["m1","m2","m3","m4","q1"]
                 data[name] = randn(105) .+ 1.0
+            end
+            CSV.write(csv_new, DataFrame(data))
+
+            e = try
+                _capture() do
+                    _nowcast_news(; data_new=csv_new, data_old=csv_old,
+                        monthly_vars=4, quarterly_vars=1, method="dfm")
+                end
+                nothing
+            catch err
+                err
+            end
+            # Upstream signals this with a bare ArgumentError — exit 1 before #85.
+            @test e isa CliError
+            @test e.code == "data/shape"
+        end
+    end
+
+    @testset "_nowcast_news — bvar method" begin
+        mktempdir() do dir
+            csv_old = _make_csv(dir; T=100, n=5, colnames=["m1","m2","m3","m4","q1"])
+            csv_new = joinpath(dir, "data_new.csv")
+            data = Dict{String,Vector{Float64}}()
+            for name in ["m1","m2","m3","m4","q1"]
+                data[name] = randn(100) .+ 1.0
             end
             CSV.write(csv_new, DataFrame(data))
 
@@ -9236,6 +9273,26 @@ end
                                       lags="aic", max_lags=nothing,
                                       trim=0.15, format="table", output="")
             end
+        end
+    end
+
+    @testset "_test_gregory_hansen — one column is data/shape (#85)" begin
+        mktempdir() do dir
+            csv = _make_csv(dir; T=100, n=1)
+            e = try
+                _capture() do
+                    _test_gregory_hansen(; data=csv, model="C",
+                                          lags="aic", max_lags=nothing,
+                                          trim=0.15, format="table", output="")
+                end
+                nothing
+            catch err
+                err
+            end
+            # A cointegrating regression needs a dependent plus a regressor;
+            # upstream raises a bare ArgumentError (exit 1 before #85).
+            @test e isa CliError
+            @test e.code == "data/shape"
         end
     end
 

--- a/test/tools/check_mock_surface.jl
+++ b/test/tools/check_mock_surface.jl
@@ -69,6 +69,56 @@ end
 
 _count_kwargs_absorbers(src::String) = length(collect(eachmatch(r";\s*kwargs\.\.\.\)", src)))
 
+"""
+    _mock_getproperty_aliases(src) → Dict{String,Vector{String}}
+
+Type name → the property symbols a mock `Base.getproperty` method special-cases.
+
+Field-subset checking is blind to these: an alias is a *method*, not a field, so a
+mock can invent `result.cips` while its declared fields stay a perfect subset of
+real. That is exactly how `test cips` shipped reading a field real MEMs does not
+have (`cips_statistic`) and still passed every gate (#84).
+"""
+function _mock_getproperty_aliases(src::String)
+    out = Dict{String,Vector{String}}()
+    # Matches both `m::T` and `m::Union{A,B}` receivers — a Union form hides just as
+    # many invented properties as a single-type one.
+    pat = r"(?s)function\s+Base\.getproperty\(\s*\w+\s*::\s*(\w+(?:\{[^}]*\})?)\s*,\s*\w+\s*::\s*Symbol\s*\)(.*?)\n\s*end"
+    for m in eachmatch(pat, src)
+        recv = m.captures[1]
+        syms = String[sm.captures[1] for sm in eachmatch(r"===\s*:(\w+)", m.captures[2])]
+        isempty(syms) && continue
+        tnames = if startswith(recv, "Union{")
+            split(recv[7:end-1], ",")
+        else
+            [recv]
+        end
+        for t in tnames
+            tn = String(strip(t))
+            isempty(tn) && continue
+            out[tn] = unique(vcat(get(out, tn, String[]), syms))
+        end
+    end
+    return out
+end
+
+"""True if the real package defines a `Base.getproperty` method specific to `T`."""
+function _real_has_custom_getproperty(T::Type)
+    for m in methods(Base.getproperty)
+        sig = m.sig
+        sig isa DataType || continue
+        length(sig.parameters) >= 2 || continue
+        argT = sig.parameters[2]
+        argT === Any && continue
+        argT isa Type || continue
+        try
+            T <: argT && return true
+        catch
+        end
+    end
+    return false
+end
+
 function main()
     real_mod = MacroEconometricModels
     hard = String[]
@@ -107,6 +157,33 @@ function main()
             end
         catch e
             println("SKIP struct $sname fields: $e")
+        end
+    end
+
+    # Property aliases invented by mock `Base.getproperty` methods (#84).
+    aliases = _mock_getproperty_aliases(MOCK_SRC)
+    for tname in sort!(collect(keys(aliases)))
+        haskey(MOCK_ALLOWLIST, tname) && continue
+        isdefined(real_mod, Symbol(tname)) || continue   # struct check already reported it
+        real_T = getfield(real_mod, Symbol(tname))
+        real_T isa Type || continue
+        real_fields = try
+            Set(string.(fieldnames(real_T)))
+        catch
+            continue
+        end
+        # If real defines its own getproperty for this type, its property surface
+        # cannot be read statically — report as soft rather than fail the gate.
+        custom = _real_has_custom_getproperty(real_T)
+        bogus = [a for a in aliases[tname] if !(a in real_fields)]
+        if isempty(bogus)
+            println("OK getproperty $tname (aliases ⊆ real fields)")
+        elseif custom
+            push!(soft, "getproperty $tname: aliases not real fields (real defines a custom " *
+                        "getproperty, verify by hand): $(join(sort(bogus), ", "))")
+        else
+            push!(hard, "getproperty $tname: mock invents properties real does not have: " *
+                        "$(join(sort(bogus), ", ")) — a handler reading these crashes on real MEMs")
         end
     end
 


### PR DESCRIPTION
Fixes the three follow-ups filed from #82: **#83**, **#84**, **#85**.

> **Stacked on #82.** Based on `fix/data-loading` so the diff stays reviewable — all three fixes touch files #82 also changes (`src/io.jl`, `test/mocks.jl`, `test/integration/runtests.jl`). Merge #82 first; this then retargets cleanly to `dev`.

The mock-surface work turned out to be load-bearing. **The new gate exposed 19 commands that crashed with exit 1 on every invocation against real MEMs, while T1/T2 stayed green.**

## #84 — `check_mock_surface` couldn't see mock-only property aliases

It compared struct **fields** only. A `Base.getproperty` alias is a *method*, not a field, so the declared fields stayed a correct subset of real and the tool reported PASS while the mock invented an entire property surface:

```julia
Base.getproperty(r::PesaranCIPSResult, s) = s === :cips ? getfield(r, :cips_statistic) : ...
```

It now parses every mock `getproperty` block — including `Union{A,B}` receivers — and hard-fails on any special-cased symbol that isn't a real field (soft only where real defines its own `getproperty`, which can't be read statically). All 28 alias blocks are deleted; the mock's own StatsAPI methods now use real field names.

Commands that were broken by those invented names, all fixed and now covered:

| Command | Read | Real field |
|---|---|---|
| `test durbin-watson` | `.decision`, `.lower_bound`, `.upper_bound` | only `statistic`/`pvalue` exist — no Savin-White bounds; reports the p-value instead |
| `test dfgls` | `.tau_statistic`, `.mgls_statistics` | `statistic`; MZa/MZt/MSB/MPT are separate fields |
| `test adf-2break` | `.break_index1`, `.break_fraction1` | `break1`, `break1_fraction` |
| `test gregory-hansen` | `.adf_break_index` | `adf_break`, `zt_break`, `za_break` |
| `test lm-unitroot` | `.break_indices` | `break_dates` |
| `test factor-break` | `.r`, `.n_units` | `n_factors`, `n_vars` |
| `fevd bvar`, `hd bvar` | `.mean`, `.initial_mean` | `point_estimate`, `initial_point_estimate` |
| `estimate favar --method bayesian` | `.n_draws` | `size(B_draws, 3)` |
| `dsge bayes irf` / `fevd` | `.mean` | `point_estimate` |

**`fevd bvar` had a second bug the alias hid:** real `BayesianFEVD.point_estimate` is `(horizon, variable, shock)`, but the shared `_output_fevd_tables` indexes `[variable, shock, horizon]` — output was transposed. The mock built its array in the *renderer's* layout, so only real was wrong. Fixed with `permutedims(…, (2,3,1))`; the mock now uses the real layout, and T3 asserts one row per horizon **and** that variance shares sum to 1.

## #85 — coverage gaps, and five `predict` leaves that never worked

`marginal-effects` / `odds-ratio` / `classification-table` were declared as **String options** while the handlers take **`Bool`** kwargs, so the default `""` failed Bool conversion on *every* call (`TypeError: non-boolean (String) used in boolean context`). `predict logit|probit|ologit|oprobit|mlogit` were all dead. They're now flags. The ordered/multinomial specs also advertised options their handlers never accepted (`MethodError`), so those are removed — re-add only together with handler support.

Further real bugs found while writing the sweep:

- `predict` on ordered/multinomial returns an `n × n_categories` **matrix**; the old scalar `DataFrame` raised *"adding AbstractArray other than AbstractVector as a column"*. New `_choice_prob_table` emits one `prob_<category>` column per category.
- `classification_table` returns a `Dict` **mixing scalars with a confusion matrix**, so `sort(collect(ct))` compared a `Matrix` against a `Float`.
- `OddsRatio`'s field is **`or`**, not `odds_ratio`.
- **`residuals ologit|oprobit|mlogit` cannot work.** MEMs defines no `residuals` for these models and there's no single standard definition — the mock had *invented* `y - fitted[:,1]`. They now throw typed `model/unsupported` (exit 5) pointing at `predict`, rather than fabricate a statistic. Flagged in the docs; removing the leaves is cleaner at v1.0 (C055).
- **`nowcast news`**: vintages must be the *same shape* — a newer vintage fills in missing cells, it doesn't add rows. The mismatch is now `data/shape`; missing-vintage errors are typed.

Coverage added to the **gating** suite: the `nowcast` family (each leaf has a different option set — `dfm` `--factors`, `bvar` only `--lags`, `bridge` `--lag-m/-q/-y`) and a `predict`/`residuals` sweep over var/bvar/vecm/arima/reg/logit/probit/garch plus the ordered/multinomial cases.

## #83 — path guard rejected legitimate paths

`contains(path, "..")` blocked ordinary parent-relative paths (no workaround in the REPL, which has no shell) and absolute paths whose *filename* merely contained two dots — while still allowing any absolute path anywhere, so it was never containment.

Confinement is now **opt-in via `FRIEDMAN_DATA_ROOT`** and compares **normalized** paths, so `..` segments resolve instead of being pattern-matched. Escaping the root is `data/bad-path` (exit 3); unset, normal filesystem access works. This is strictly *more* containment than before, where the check stopped nothing an attacker would do.

Also typed four bare `error()` sites on these paths (`--key-vars`, `--tcodes`, nowcast method/vintages) so bad input exits 2/3 rather than 1.

## Gates

- T1/T2 exit 0
- **T3 1498/1498** (1232 before #82) + entry points 49/49
- mock-surface PASS *with the new alias check active*
- inventory 303 unchanged · `docs --check` OK · gitleaks + semgrep clean

Docs updated: `commands/predict_residuals.md` (flags vs options, per-category columns, the unsupported-residuals refusal), `commands/ordered-multinomial.md`, generated `predict.md`.

Closes #83, #84, #85.

https://claude.ai/code/session_01A3ZbaiZy1VxQSRf13zNK69