### PR TITLE
fix(test): missing required option is usage/missing, not an internal exit 1

### DIFF
--- a/src/commands/test.jl
+++ b/src/commands/test.jl
@@ -3152,7 +3152,8 @@ end
 function _test_hausman(; data::String, dep::String="", indep::String="",
                         id_col::String="", time_col::String="",
                         output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3175,7 +3176,8 @@ end
 function _test_breusch_pagan(; data::String, dep::String="", indep::String="",
                               id_col::String="", time_col::String="",
                               output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3197,7 +3199,8 @@ end
 function _test_f_fe(; data::String, dep::String="", indep::String="",
                      id_col::String="", time_col::String="",
                      output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3219,7 +3222,8 @@ end
 function _test_pesaran_cd(; data::String, dep::String="", indep::String="",
                            id_col::String="", time_col::String="",
                            output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3240,7 +3244,8 @@ end
 function _test_wooldridge_ar(; data::String, dep::String="", indep::String="",
                               id_col::String="", time_col::String="",
                               output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3262,7 +3267,8 @@ end
 function _test_modified_wald(; data::String, dep::String="", indep::String="",
                               id_col::String="", time_col::String="",
                               output::String="", format::String="table")
-    isempty(dep) && error("--dep is required")
+    isempty(dep) && throw(CliError("usage/missing", "--dep is required";
+        hint="name the dependent variable column, e.g. --dep y"))
     pd = _load_panel_for_preg(data, id_col, time_col)
     indep_syms = _parse_indep_vars(pd, dep, indep)
 
@@ -3399,7 +3405,8 @@ function _test_hausman_iia(; data::String, dep::String="", omit_category=nothing
     y, X, xcols = _load_reg_data(data, dep)
     dep_name = isempty(dep) ? variable_names(load_data(data))[1] : dep
 
-    isnothing(omit_category) && error("--omit-category is required")
+    isnothing(omit_category) && throw(CliError("usage/missing", "--omit-category is required";
+        hint="name the alternative to drop, e.g. --omit-category 2"))
 
     model = estimate_mlogit(y, X; cov_type=:ols, varnames=xcols)
 

--- a/test/test_commands.jl
+++ b/test/test_commands.jl
@@ -9837,6 +9837,40 @@ end
                 end
             end
         end
+
+        @testset "missing required option → usage/missing, not internal exit 1" begin
+            # These seven handlers guarded their required option with a bare error(),
+            # which run_cli reports as internal/error exit 1 "likely a bug" for what is
+            # an ordinary usage mistake. Same class as the shared-loader hardenings.
+            mktempdir() do dir
+                panel = _make_panel_csv(dir; G=6, T_per=20, n=2, colnames=["y", "x1"])
+                csv = _make_csv(dir; T=100, n=4)
+                for h in (_test_hausman, _test_breusch_pagan, _test_f_fe,
+                          _test_pesaran_cd, _test_wooldridge_ar, _test_modified_wald)
+                    e = try
+                        _capture() do
+                            h(; data=panel, dep="", indep="", id_col="", time_col="",
+                               format="table", output="")
+                        end
+                        nothing
+                    catch err
+                        err
+                    end
+                    @test e isa CliError
+                    @test e.code == "usage/missing" && exit_class(e) == 2
+                end
+                e = try
+                    _capture() do
+                        _test_hausman_iia(; data=csv, dep="var1", omit_category=nothing,
+                                           format="table", output="")
+                    end
+                    nothing
+                catch err
+                    err
+                end
+                @test e isa CliError && e.code == "usage/missing" && exit_class(e) == 2
+            end
+        end
     end
 
 end


### PR DESCRIPTION
Seven `test` handlers guarded their required option with a bare `error()`:

| handler | guard |
|---|---|
| `test hausman`, `breusch-pagan`, `f-fe`, `pesaran-cd`, `wooldridge-ar`, `modified-wald` | `error("--dep is required")` |
| `test hausman-iia` | `error("--omit-category is required")` |

`error()` is reserved for internal invariants, so `run_cli` reported each as
`internal/error`, **exit 1, "likely a bug"** — for an ordinary usage mistake that
should be `usage/missing`, exit 2. Since this CLI is agent-first, an agent parsing
the exit code reads a forgotten flag as a defect in the tool.

Now typed `CliError` with a hint naming what to pass. Same class as the shared
data-loader hardenings recorded in CLAUDE.md. Found while reading `test.jl` for the
#72 wave.

Regression test covers all seven handlers. T1/T2 1311/1311, gitleaks clean.