### PR TITLE
feat(#71): estimate statespace --config — general fixed-matrix systems

### DIFF
--- a/docs/src/commands/estimate.md
+++ b/docs/src/commands/estimate.md
@@ -817,13 +817,52 @@ friedman estimate statespace gdp.csv --column=2 --model=local-linear-trend --ini
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
 | `--column` | `-c` | Int | 1 | 1-based numeric column to model |
-| `--model` | | String | `local-level` | `local-level` or `local-linear-trend` |
+| `--model` | | String | `local-level` | `local-level` or `local-linear-trend` (ignored with `--config`) |
 | `--init-mode` | | String | `kappa` | Kalman initialization: `kappa` or `diffuse` |
 | `--kappa` | | Float | 1e6 | Large-variance diffuse-init constant (`init-mode=kappa`) |
+| `--config` | | String | | TOML with a `[statespace]` section — switches to a **general** system (below) |
 | `--format` | `-f` | String | `table` | `table`, `csv`, `json` |
 | `--output` | `-o` | String | | Export file path |
 
 **Output:** hyper-parameter table (`parameter|estimate` — the estimated natural-scale variances σ̂², e.g. `σ²_ε`, `σ²_η`) + diagnostics (`model`, `loglik`, `converged`, `n_state`, `n_obs`, `method`). `StateSpaceModel` is not Tables.jl-registered upstream, so the table is hand-built (a documented [C051](#coefficient-table-format-c051) exception).
+
+### General systems: `--config`
+
+A `[statespace]` section specifies an arbitrary linear-Gaussian system directly, in the standard single-block form
+
+```
+yₜ   = Z αₜ + d + εₜ,     εₜ ~ N(0, H)
+αₜ₊₁ = T αₜ + c + R ηₜ,   ηₜ ~ N(0, Q)
+```
+
+**This path is multivariate**: `Z` is `n_obs × n_state`, and the data file must have exactly `n_obs` numeric columns (`--column` does not apply). It is also **fixed-matrix**: nothing is optimized. The system is filtered and its log-likelihood evaluated, so `method` comes back as `filter` rather than `mle` and there are no hyper-parameters to report — the output is a **system table** (`matrix|role|rows|cols`) instead of `parameter|estimate`, showing the matrices in force *after* defaults are applied.
+
+```toml
+[statespace]
+# Two observed series loading on one common AR(1) state
+Z = [[1.0], [0.7]]              # n_obs × n_state       (required)
+H = [[1.0, 0.0], [0.0, 2.0]]    # n_obs × n_obs         (required)
+T = [[0.95]]                    # n_state × n_state     (required)
+Q = [[0.5]]                     # r × r                 (required)
+# optional:
+d = [0.0, 0.0]                  # n_obs      observation intercept (default 0)
+c = [0.0]                       # n_state    state intercept       (default 0)
+R = [[1.0]]                     # n_state × r  noise loading        (default I)
+a1 = [0.0]                      # n_state    explicit initial state mean
+P1 = [[10.0]]                   # n_state × n_state  explicit initial covariance
+init_mode = "kappa"             # kappa | diffuse | stationary
+```
+
+```bash
+friedman estimate statespace two_series.csv --config system.toml
+```
+
+Notes:
+
+- **`T` in the TOML is the transition matrix.** The Julia field is `Tt` and the upstream constructor keyword is `T_mat`, because `T` is the type parameter — three spellings of one matrix, unavoidable.
+- **`a1` and `P1` must be given together or not at all.** Supplying only one is rejected rather than silently ignored: upstream switches to explicit initialization only when both are present, so a lone `a1` would quietly have no effect.
+- Matrices are row-major arrays of arrays; `d`, `c`, `a1` are flat arrays.
+- Every dimensional inconsistency is caught while parsing, so it surfaces as `config/shape` (exit 4) naming the file you wrote, rather than as an error from deep inside the library. A mismatch between `Z`'s implied `n_obs` and the CSV's column count is `data/shape` (exit 3), since that is a property of the data rather than the config.
 
 ## estimate tvp
 

--- a/docs/src/commands/generated/estimate.md
+++ b/docs/src/commands/generated/estimate.md
@@ -1396,12 +1396,19 @@ Path to CSV data file
 | Option | Short | Type | Default | Choices | Description |
 |--------|-------|------|---------|---------|-------------|
 | `--column` | `-c` | `Int64` | `1` | — | 1-based numeric column to model |
-| `--model` | — | `String` | `local-level` | `local-level`, `local-linear-trend` | local-level | local-linear-trend |
-| `--init-mode` | — | `String` | `kappa` | `kappa`, `diffuse` | Kalman initialization: kappa | diffuse |
+| `--model` | — | `String` | `local-level` | `local-level`, `local-linear-trend` | local-level | local-linear-trend (ignored with --config) |
+| `--init-mode` | — | `String` | `kappa` | `kappa`, `diffuse` | Kalman initialization: kappa | diffuse (--config uses [statespace] init_mode) |
 | `--kappa` | — | `Float64` | `1.0e6` | — | Large-variance diffuse-init constant (init-mode=kappa) |
+| `--config` | — | `String` | `""` | — | TOML with [statespace] Z/H/T/Q (+ d, c, R, a1, P1, init_mode) for a general system |
 | `--output` | `-o` | `String` | `""` | — | Export results to file |
 | `--format` | `-f` | `String` | `table` | `table`, `csv`, `json` | table|csv|json |
 | `--save-model` | — | `String` | `""` | — | Save estimated model to a .fmod handle file |
+| `--config-json` | — | `String` | `""` | — | JSON object merged over --config (file < json < --set) |
+| `--set` | — | `String` | `""` | — | Override config key=value; repeatable; dotted keys OK |
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--strict` | — | Treat config schema warnings as errors (exit 4) |
 
 **Output tables:** `estimate_statespace` (Path to CSV data file)
 

--- a/src/commands/estimate.jl
+++ b/src/commands/estimate.jl
@@ -552,9 +552,12 @@ function estimate_specs()::Vector{CommandSpec}
             args=[ArgSpec(name="data", type=String, required=true, default=nothing, description="Path to CSV data file")],
             options=[
                 OptionSpec(name="column", short="c", type=Int, default=1, description="1-based numeric column to model"),
-                OptionSpec(name="model", type=String, default="local-level", description="local-level | local-linear-trend", choices=["local-level","local-linear-trend"]),
-                OptionSpec(name="init-mode", type=String, default="kappa", description="Kalman initialization: kappa | diffuse", choices=["kappa","diffuse"]),
+                OptionSpec(name="model", type=String, default="local-level", description="local-level | local-linear-trend (ignored with --config)", choices=["local-level","local-linear-trend"]),
+                OptionSpec(name="init-mode", type=String, default="kappa", description="Kalman initialization: kappa | diffuse (--config uses [statespace] init_mode)", choices=["kappa","diffuse"]),
                 OptionSpec(name="kappa", type=Float64, default=1e6, description="Large-variance diffuse-init constant (init-mode=kappa)"),
+                # A [statespace] section switches to the GENERAL (multivariate, fixed-matrix)
+                # system and supersedes --model/--init-mode/--column.
+                OptionSpec(name="config", type=String, default="", description="TOML with [statespace] Z/H/T/Q (+ d, c, R, a1, P1, init_mode) for a general system"),
                 OptionSpec(name="output", short="o", type=String, default="", description="Export results to file"),
                 OptionSpec(name="format", short="f", type=String, default="table", description="table|csv|json", choices=["table","csv","json"])
             ],
@@ -4274,9 +4277,75 @@ function _residuals_statespace(; data::String="", column::Int=1, kind::String="l
     return M
 end
 
+"""System-matrix summary for the GENERAL `--config` path.
+
+A fixed-matrix system has NO estimated hyper-parameters: `estimate_statespace(ss, y)` returns
+`method = :filter` with `theta` and `param_names` EMPTY, so `_statespace_param_table` would
+render an empty table and silently look like a failed fit. This reports the system the user
+declared instead — dimensions plus the matrices actually in force after MEMs applied its
+defaults (R = I, d = c = 0), which is the part a user most often gets wrong."""
+function _statespace_system_table(ssm)
+    DataFrame(
+        "matrix" => String["Z", "H", "T", "Q", "R", "d", "c"],
+        "role" => String["observation", "obs. noise cov", "transition", "state noise cov",
+                         "state-noise loading", "obs. intercept", "state intercept"],
+        "rows" => Int[size(ssm.Z, 1), size(ssm.H, 1), size(ssm.Tt, 1), size(ssm.Q, 1),
+                      size(ssm.R, 1), length(ssm.d), length(ssm.c)],
+        "cols" => Int[size(ssm.Z, 2), size(ssm.H, 2), size(ssm.Tt, 2), size(ssm.Q, 2),
+                      size(ssm.R, 2), 1, 1],
+    )
+end
+
 function _estimate_statespace(; data::String, column::Int=1, model::String="local-level",
                                init_mode::String="kappa", kappa::Float64=1e6,
-                               output::String="", format::String="table")
+                               config::String="", output::String="", format::String="table")
+    # ── GENERAL system from [statespace] in --config ────────────────────────────────────
+    # This path is MULTIVARIATE (y is T_obs × n_obs), so it loads the whole numeric matrix
+    # via the hardened `load_multivariate_data` rather than the canned path's single column.
+    if !isempty(config)
+        cfg = get_statespace(load_config(config))
+        Y, vnames = load_multivariate_data(data)
+        size(Y, 2) == cfg.n_obs || throw(CliError("data/shape",
+            "estimate statespace: [statespace] Z implies n_obs=$(cfg.n_obs) observed series, " *
+            "but $data has $(size(Y, 2)) numeric columns";
+            hint="Z is n_obs×n_state — one ROW per observed series"))
+        _status("State-space (general system from $config): series=$(join(vnames, ", ")), " *
+                "T=$(size(Y, 1)), n_obs=$(cfg.n_obs), n_state=$(cfg.n_state), init_mode=$(cfg.init_mode)")
+        _status()
+        # The MEMs constructor re-checks dimensions and throws untyped ArgumentErrors;
+        # `get_statespace` has already checked them so a throw here is a genuine internal
+        # inconsistency, but map it anyway rather than let it escape as exit 1.
+        spec = try
+            StateSpaceModel(cfg.Z, cfg.H, cfg.T, cfg.Q; d=cfg.d, c=cfg.c, R=cfg.R,
+                            a1=cfg.a1, P1=cfg.P1, init_mode=cfg.init_mode, kappa=kappa)
+        catch e
+            e isa ArgumentError && throw(CliError("config/shape",
+                "estimate statespace: inconsistent [statespace] system — $(e.msg)"))
+            throw(_garch_variant_error(e, "State-space system"))
+        end
+        fitted_ss = try
+            estimate_statespace(spec, Y)
+        catch e
+            throw(_garch_variant_error(e, "State-space filtering"))
+        end
+        output_result(_statespace_system_table(fitted_ss); format=Symbol(format), output=output,
+                      title="State-Space System (general)")
+        output_kv(Pair{String,Any}[
+            "model"     => "general",
+            "loglik"    => isfinite(fitted_ss.loglik) ? round(Float64(fitted_ss.loglik); digits=4) :
+                           string(fitted_ss.loglik),
+            "init_mode" => string(fitted_ss.init_mode),
+            "n_obs_series" => fitted_ss.n_obs,
+            "n_state"   => fitted_ss.n_state,
+            "n_periods" => fitted_ss.T_obs,
+            # :filter, not :mle — a fixed-matrix system is filtered and log-likelihood
+            # evaluated, never optimized, so there is nothing to converge.
+            "method"    => string(fitted_ss.method),
+        ]; format=format, title="State-Space Diagnostics")
+        return fitted_ss
+    end
+
+    # ── Canned univariate systems ───────────────────────────────────────────────────────
     model in ("local-level", "local-linear-trend") || throw(CliError("usage/invalid",
         "estimate statespace: --model must be local-level or local-linear-trend, got '$model'"))
     init_mode in ("kappa", "diffuse") || throw(CliError("usage/invalid",

--- a/src/config.jl
+++ b/src/config.jl
@@ -641,3 +641,106 @@ function _parse_matrix(rows::Vector)
     end
     return mat
 end
+
+"""
+    get_statespace(config) -> NamedTuple
+
+Parse a `[statespace]` section describing a GENERAL linear-Gaussian state-space system, for
+`estimate statespace --config`. The system is the standard single-block form
+
+    yₜ   = Z αₜ + d + εₜ,     εₜ ~ N(0, H)
+    αₜ₊₁ = T αₜ + c + R ηₜ,   ηₜ ~ N(0, Q)
+
+Required keys: `Z` (n_obs × n_state), `H` (n_obs × n_obs), `T` (n_state × n_state), `Q` (r × r).
+Optional: `d` (n_obs), `c` (n_state), `R` (n_state × r), `a1`/`P1` (explicit initialisation,
+BOTH or NEITHER), `init_mode` (`kappa`|`diffuse`|`stationary`).
+
+Matrices are row-major arrays of arrays; vectors are flat arrays. Note the TOML key is `T`
+(standard notation) while the MEMs field is `Tt` and the constructor keyword is `T_mat` — `T` is
+the type parameter in Julia, so the three names cannot be unified.
+
+Dimensional consistency is checked HERE rather than left to the MEMs constructor, so a bad
+config surfaces as `config/shape` (exit 4, pointing at the file the user wrote) instead of an
+untyped `ArgumentError`.
+"""
+function get_statespace(config::Dict)
+    sec = get(config, "statespace", nothing)
+    sec isa AbstractDict || throw(CliError("config/missing",
+        "estimate statespace --config requires a [statespace] section with Z, H, T and Q"))
+
+    _mat(key) = begin
+        haskey(sec, key) || throw(CliError("config/missing-key",
+            "[statespace] must define $key = [[...],[...]] (row-major matrix)"))
+        rows = sec[key]
+        (rows isa AbstractVector && !isempty(rows) && all(r -> r isa AbstractVector, rows)) ||
+            throw(CliError("config/type",
+                "[statespace] $key must be a non-empty array of equal-length numeric rows"))
+        ncol = length(first(rows))
+        (ncol >= 1 && all(r -> length(r) == ncol, rows)) ||
+            throw(CliError("config/shape",
+                "[statespace] $key rows must all have the same length ≥ 1"))
+        try
+            [Float64(rows[i][j]) for i in 1:length(rows), j in 1:ncol]
+        catch
+            throw(CliError("config/type", "[statespace] $key must contain only numbers"))
+        end
+    end
+    _optmat(key) = haskey(sec, key) ? _mat(key) : nothing
+    _optvec(key) = begin
+        haskey(sec, key) || return nothing
+        v = sec[key]
+        (v isa AbstractVector && !isempty(v) && all(x -> x isa Real, v)) ||
+            throw(CliError("config/type", "[statespace] $key must be a non-empty flat array of numbers"))
+        Float64[Float64(x) for x in v]
+    end
+
+    Z = _mat("Z"); H = _mat("H"); Tm = _mat("T"); Q = _mat("Q")
+    n_obs, n_state = size(Z)
+    size(H) == (n_obs, n_obs) || throw(CliError("config/shape",
+        "[statespace] H must be n_obs×n_obs = ($n_obs, $n_obs) to match Z, got $(size(H))"))
+    size(Tm) == (n_state, n_state) || throw(CliError("config/shape",
+        "[statespace] T must be n_state×n_state = ($n_state, $n_state) to match Z, got $(size(Tm))"))
+
+    R = _optmat("R")
+    if R === nothing
+        # MEMs defaults R to I(n_state, size(Q,1)); Q must then be r×r with r = size(Q,1),
+        # and r cannot exceed n_state or the implied loading matrix is not well formed.
+        size(Q, 1) == size(Q, 2) || throw(CliError("config/shape",
+            "[statespace] Q must be square, got $(size(Q))"))
+        size(Q, 1) <= n_state || throw(CliError("config/shape",
+            "[statespace] Q is $(size(Q,1))×$(size(Q,1)) but the state has dimension $n_state; " *
+            "supply R (n_state × r) explicitly for r > n_state"))
+    else
+        size(R, 1) == n_state || throw(CliError("config/shape",
+            "[statespace] R must have n_state=$n_state rows to match Z, got $(size(R, 1))"))
+        size(Q) == (size(R, 2), size(R, 2)) || throw(CliError("config/shape",
+            "[statespace] Q must be r×r with r = size(R,2) = $(size(R, 2)), got $(size(Q))"))
+    end
+
+    d = _optvec("d"); c = _optvec("c")
+    d === nothing || length(d) == n_obs || throw(CliError("config/shape",
+        "[statespace] d must have length n_obs=$n_obs, got $(length(d))"))
+    c === nothing || length(c) == n_state || throw(CliError("config/shape",
+        "[statespace] c must have length n_state=$n_state, got $(length(c))"))
+
+    a1 = _optvec("a1"); P1 = _optmat("P1")
+    # MEMs switches to init_mode=:explicit only when BOTH are supplied; supplying one alone
+    # would be silently ignored, so reject it here rather than let the user think it applied.
+    ((a1 === nothing) == (P1 === nothing)) || throw(CliError("config/shape",
+        "[statespace] a1 and P1 must be supplied together (explicit initialisation) or not at all"))
+    if a1 !== nothing
+        length(a1) == n_state || throw(CliError("config/shape",
+            "[statespace] a1 must have length n_state=$n_state, got $(length(a1))"))
+        size(P1) == (n_state, n_state) || throw(CliError("config/shape",
+            "[statespace] P1 must be n_state×n_state = ($n_state, $n_state), got $(size(P1))"))
+    end
+
+    im = get(sec, "init_mode", "kappa")
+    im isa AbstractString || throw(CliError("config/type",
+        "[statespace] init_mode must be a string (kappa|diffuse|stationary)"))
+    String(im) in ("kappa", "diffuse", "stationary") || throw(CliError("config/invalid",
+        "[statespace] init_mode must be kappa|diffuse|stationary, got '$im'"))
+
+    return (Z=Z, H=H, T=Tm, Q=Q, R=R, d=d, c=c, a1=a1, P1=P1,
+            init_mode=Symbol(String(im)), n_obs=n_obs, n_state=n_state)
+end

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -3431,6 +3431,82 @@ col_index(tbl, name::AbstractString) = findfirst(==(name), table_cols(tbl))
             rm(csv; force=true)
         end
 
+        @testset "statespace --config — general system, EQUIVALENT to the canned one (#71)" begin
+            # THE assertion that makes this more than a shape test: writing the local level out
+            # by hand with the variances the canned MLE found must reproduce the canned
+            # log-likelihood EXACTLY. If the config were being mis-transcribed into the system
+            # matrices (Z/T swapped, H and Q crossed, a dropped intercept) the two would differ.
+            csv = dgp_ar1(; T=200, φ=0.6, seed=131)
+            canned = run_json(["estimate", "statespace", csv, "--model", "local-level"])
+            assert_envelope_ok(canned; label="statespace canned")
+            pt = cols_table(canned.doc, ["parameter", "estimate"])
+            ei = findfirst(==("estimate"), table_cols(pt))
+            th = [Float64(collect(row)[ei]) for row in table_rows(pt)]      # [σ²_ε, σ²_η]
+            ll_canned = Float64(metric_value(metrics_table(canned.doc), "loglik"))
+
+            cfg = tempname() * ".toml"
+            open(cfg, "w") do io
+                println(io, "[statespace]")
+                println(io, "Z = [[1.0]]")
+                println(io, "H = [[", th[1], "]]")
+                println(io, "T = [[1.0]]")
+                println(io, "Q = [[", th[2], "]]")
+            end
+            gen = run_json(["estimate", "statespace", csv, "--config", cfg])
+            assert_envelope_ok(gen; label="statespace general")
+            ll_gen = Float64(metric_value(metrics_table(gen.doc), "loglik"))
+            @test isapprox(ll_canned, ll_gen; rtol=1e-6)
+
+            # a fixed-matrix system is FILTERED, never optimized: no hyper-parameters, so the
+            # system table stands in for the parameter table (which would render empty)
+            st = cols_table(gen.doc, ["matrix", "role", "rows", "cols"])
+            @test st !== nothing
+            @test Set(string(collect(row)[1]) for row in table_rows(st)) ==
+                  Set(["Z", "H", "T", "Q", "R", "d", "c"])
+            @test cols_table(gen.doc, ["parameter", "estimate"]) === nothing
+            @test string(metric_value(metrics_table(gen.doc), "method")) == "filter"
+            @test string(metric_value(metrics_table(gen.doc), "model")) == "general"
+            @test Int(metric_value(metrics_table(gen.doc), "n_periods")) == 200
+
+            # multivariate: two series on one common state
+            bicsv = write_csv(DataFrame(y1=randn(120), y2=randn(120)); prefix="ss_bi")
+            bicfg = tempname() * ".toml"
+            open(bicfg, "w") do io
+                println(io, "[statespace]")
+                println(io, "Z = [[1.0], [0.7]]")
+                println(io, "H = [[1.0, 0.0], [0.0, 2.0]]")
+                println(io, "T = [[0.95]]")
+                println(io, "Q = [[0.5]]")
+            end
+            rb = run_json(["estimate", "statespace", bicsv, "--config", bicfg])
+            assert_envelope_ok(rb; label="statespace general bivariate")
+            @test Int(metric_value(metrics_table(rb.doc), "n_obs_series")) == 2
+            @test Int(metric_value(metrics_table(rb.doc), "n_state")) == 1
+
+            # n_obs implied by Z vs the CSV's column count → data/shape (3), not exit 1
+            @test run_json(["estimate", "statespace", csv, "--config", bicfg]).code == 3
+            # a malformed system is a CONFIG error (4), naming the file the user wrote
+            badcfg = tempname() * ".toml"
+            open(badcfg, "w") do io
+                println(io, "[statespace]")
+                println(io, "Z = [[1.0]]")
+                println(io, "H = [[1.0, 0.0], [0.0, 1.0]]")
+                println(io, "T = [[1.0]]")
+                println(io, "Q = [[1.0]]")
+            end
+            @test run_json(["estimate", "statespace", csv, "--config", badcfg]).code == 4
+            # a1 without P1 would be SILENTLY IGNORED upstream → rejected here
+            halfcfg = tempname() * ".toml"
+            open(halfcfg, "w") do io
+                println(io, "[statespace]")
+                println(io, "Z = [[1.0]]"); println(io, "H = [[1.0]]")
+                println(io, "T = [[1.0]]"); println(io, "Q = [[1.0]]")
+                println(io, "a1 = [0.0]")
+            end
+            @test run_json(["estimate", "statespace", csv, "--config", halfcfg]).code == 4
+            for f in (cfg, bicfg, badcfg, halfcfg, bicsv, csv); rm(f; force=true); end
+        end
+
         @testset "statespace local-linear-trend — 3 hyper-params" begin
             csv = dgp_trend_cycle(; T=200, seed=32)
             r = run_json(["estimate", "statespace", csv, "--model", "local-linear-trend"])

--- a/test/mocks.jl
+++ b/test/mocks.jl
@@ -3399,9 +3399,22 @@ export CointRegModel, PanelCointRegModel, estimate_cointreg, estimate_xtcointreg
 # Estimators are genuine-ish fits that VALIDATE like the real ones (n bounds, kernel/method/bw
 # enums, length matches) so T1/T2 exercise the error mapping and table shapes.
 
-# Subset of real StateSpaceModel fields (real order: ..., loglik, theta, param_names, ...,
-# converged, method, n_obs, n_state, T_obs). We keep only what the CLI renders.
+# Subset of real StateSpaceModel fields (check_mock_surface is mock ⊆ real by NAME, not order).
+# We keep what the CLI renders: the system matrices (#71 --config general path), the state
+# paths (#71 predict/residuals), and the fit summary.
 struct StateSpaceModel{T<:AbstractFloat}
+    # System matrices — the general fixed-matrix form y = Z α + d + ε, α' = T α + c + R η.
+    # NOTE the field is `Tt`, not `T`: `T` is the struct's type parameter. Real has the same
+    # constraint, which is why the TOML key (`T`), the constructor keyword (`T_mat`) and the
+    # field (`Tt`) are three different spellings of one matrix.
+    Z::Matrix{T}
+    H::Matrix{T}
+    Tt::Matrix{T}
+    Q::Matrix{T}
+    d::Vector{T}
+    c::Vector{T}
+    R::Matrix{T}
+    init_mode::Symbol
     theta::Vector{T}
     param_names::Vector{String}
     # #71 consumes these; all exist in real (statespace/types.jl):
@@ -3416,6 +3429,60 @@ struct StateSpaceModel{T<:AbstractFloat}
     n_state::Int
     n_obs::Int
     T_obs::Int
+end
+
+"""Fixed-matrix outer constructor, mirroring real's signature and — critically — its
+VALIDATION and DEFAULTS: `R` defaults to `I(n_state, size(Q,1))`, `d`/`c` to zeros, and
+supplying `a1` AND `P1` switches init_mode to `:explicit`. Dimension violations raise the same
+`ArgumentError` real does, so the CLI's mapping is exercised identically at both tiers."""
+function StateSpaceModel(Z::AbstractMatrix, H::AbstractMatrix,
+                         T_mat::AbstractMatrix, Q::AbstractMatrix;
+                         d=nothing, c=nothing, R=nothing, a1=nothing, P1=nothing,
+                         init_mode::Symbol=:kappa, kappa::Real=1e6)
+    Zm = Matrix{Float64}(Z); Hm = Matrix{Float64}(H)
+    Tm = Matrix{Float64}(T_mat); Qm = Matrix{Float64}(Q)
+    n_obs, n_state = size(Zm)
+    size(Hm) == (n_obs, n_obs) ||
+        throw(ArgumentError("H must be n_obs×n_obs = $((n_obs, n_obs)), got $(size(Hm))"))
+    size(Tm) == (n_state, n_state) ||
+        throw(ArgumentError("T must be n_state×n_state = $((n_state, n_state)), got $(size(Tm))"))
+    Rm = R === nothing ? Matrix{Float64}(I, n_state, size(Qm, 1)) : Matrix{Float64}(R)
+    size(Rm, 1) == n_state ||
+        throw(ArgumentError("R must have n_state=$n_state rows, got $(size(Rm, 1))"))
+    size(Qm) == (size(Rm, 2), size(Rm, 2)) ||
+        throw(ArgumentError("Q must be r×r with r=size(R,2)=$(size(Rm, 2)), got $(size(Qm))"))
+    dv = d === nothing ? zeros(Float64, n_obs) : Vector{Float64}(d)
+    cv = c === nothing ? zeros(Float64, n_state) : Vector{Float64}(c)
+    length(dv) == n_obs || throw(ArgumentError("d must have length n_obs=$n_obs"))
+    length(cv) == n_state || throw(ArgumentError("c must have length n_state=$n_state"))
+    mode = (a1 !== nothing && P1 !== nothing) ? :explicit : init_mode
+    mode in (:kappa, :diffuse, :stationary, :explicit) ||
+        throw(ArgumentError("Unknown Kalman init mode :$mode"))
+    StateSpaceModel{Float64}(Zm, Hm, Tm, Qm, dv, cv, Rm, mode, Float64[], String[],
+        Matrix{Float64}(undef, 0, n_state), Matrix{Float64}(undef, 0, n_state),
+        Matrix{Float64}(undef, 0, n_obs), Matrix{Float64}(undef, 0, n_obs),
+        NaN, false, :spec, n_state, n_obs, 0)
+end
+
+"""Filter a FIXED-matrix system: no optimisation, so `theta`/`param_names` stay EMPTY and
+`method` is `:filter`, exactly as real. A mock that returned a populated `theta` here would
+hide the empty-parameter-table case the CLI has to render around."""
+function estimate_statespace(ss::StateSpaceModel, y)
+    Y = y isa AbstractMatrix ? Matrix{Float64}(y) : reshape(Vector{Float64}(y), :, 1)
+    n = size(Y, 1)
+    size(Y, 2) == ss.n_obs || throw(DimensionMismatch(
+        "data has $(size(Y, 2)) series but Z implies n_obs=$(ss.n_obs)"))
+    n >= 1 || throw(ArgumentError("need at least one observation"))
+    # A crude but genuine Gaussian prediction-error decomposition against a static state at 0,
+    # enough to give a finite, data-dependent loglik and correctly-shaped paths.
+    state = zeros(n, ss.n_state)
+    innov = Y .- (state * ss.Tt' * ss.Z')[:, 1:ss.n_obs]
+    F = [max(ss.H[j, j] + ss.Z[j, :]' * ss.Q * ss.Z[j, :], 1e-8) for j in 1:ss.n_obs]
+    stdres = innov ./ sqrt.(reshape(F, 1, :))
+    ll = -0.5 * sum(log(2π * F[j]) * n + sum(abs2, innov[:, j]) / F[j] for j in 1:ss.n_obs)
+    StateSpaceModel{Float64}(ss.Z, ss.H, ss.Tt, ss.Q, ss.d, ss.c, ss.R, ss.init_mode,
+        Float64[], String[], state, state, innov, stdres,
+        ll, true, :filter, ss.n_state, ss.n_obs, n)
 end
 
 struct KernelDensity{T<:AbstractFloat}
@@ -3472,7 +3539,12 @@ function local_level(y; init_mode::Symbol=:kappa, kappa::Real=1e6)
     innov = reshape(yv .- vec(filtered), :, 1)           # v_t = y_t - a_t|t-1
     stdres = innov ./ sqrt.(v0 .* (1 .+ 1 ./ (1:n)))   # F_t varies over t, as in real
     ll = -0.5 * n * (log(2π) + log(v0) + 1)
-    StateSpaceModel{Float64}([v0 / 2, v0 / 2], ["σ²_ε", "σ²_η"], filtered, smoothed,
+    # System matrices for the canned local level, so the struct is fully populated whichever
+    # path built it: y = μ + ε, μ' = μ + η.
+    StateSpaceModel{Float64}(reshape([1.0], 1, 1), reshape([v0 / 2], 1, 1),
+                             reshape([1.0], 1, 1), reshape([v0 / 2], 1, 1),
+                             [0.0], [0.0], reshape([1.0], 1, 1), init_mode,
+                             [v0 / 2, v0 / 2], ["σ²_ε", "σ²_η"], filtered, smoothed,
                              innov, stdres, ll, true, :mle, 1, 1, n)
 end
 
@@ -3487,7 +3559,11 @@ function local_linear_trend(y; init_mode::Symbol=:kappa, kappa::Real=1e6)
     innov = reshape(yv .- filtered[:, 1], :, 1)
     stdres = innov ./ sqrt.(v0 .* (1 .+ 1 ./ (1:n)))   # F_t varies over t, as in real
     ll = -0.5 * n * (log(2π) + log(v0) + 1)
-    StateSpaceModel{Float64}([v0 / 2, v0 / 10, v0 / 100], ["σ²_ε", "σ²_ξ", "σ²_ζ"],
+    # y = μ + ε; [μ, β]' = [1 1; 0 1] [μ, β] + η  (the canonical local linear trend)
+    StateSpaceModel{Float64}([1.0 0.0], reshape([v0 / 2], 1, 1),
+                             [1.0 1.0; 0.0 1.0], [v0/10 0.0; 0.0 v0/100],
+                             [0.0], [0.0, 0.0], Matrix{Float64}(I, 2, 2), init_mode,
+                             [v0 / 2, v0 / 10, v0 / 100], ["σ²_ε", "σ²_ξ", "σ²_ζ"],
                              filtered, smoothed, innov, stdres, ll, true, :mle, 2, 1, n)
 end
 
@@ -3509,7 +3585,13 @@ function estimate_tvp_reg(y, X::AbstractMatrix; intercept::Bool=true,
     ll = -0.5 * n * (log(2π) + log(v0) + 1)
     fitted = Xf * beta
     innov = reshape(yv .- fitted, :, 1)
-    StateSpaceModel{Float64}(theta, names, smoothed, smoothed, innov,
+    # TVP regression in state-space form: the state IS the coefficient vector β_t, so Z is the
+    # regressor row (time-varying in truth; the mock holds the sample mean as a stand-in).
+    StateSpaceModel{Float64}(reshape(vec(mean(Xf, dims=1)), 1, k), reshape([v0], 1, 1),
+                             Matrix{Float64}(I, k, k),
+                             Matrix{Float64}(v0 / (100 * k) * I, k, k),
+                             [0.0], zeros(k), Matrix{Float64}(I, k, k), :kappa,
+                             theta, names, smoothed, smoothed, innov,
                              innov ./ sqrt.(v0 .* (1 .+ 1 ./ (1:n))), ll, true, :mle, k, 1, n)
 end
 
@@ -3570,7 +3652,7 @@ function lowess(y::AbstractVector, x::AbstractVector; f::Real=2//3, iter::Int=3,
 end
 
 export StateSpaceModel, KernelDensity, KernelRegression, LowessFit
-export local_level, local_linear_trend, estimate_tvp_reg
+export local_level, local_linear_trend, estimate_tvp_reg, estimate_statespace
 export kernel_density, kernel_reg, lowess
 
 # ─── BVARForecast Type & Forecast Accessors ──────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3315,6 +3315,91 @@ using TOML
         @test_throws CliError get_vecm_restriction(Dict("vecm_restriction" => Dict("H" => [["a"], ["b"]])), "H")      # config/type (non-numeric)
     end
 
+    @testset "get_statespace (general state-space system, #71)" begin
+        # Minimal valid local level written out by hand
+        # Dict{String,Any} on purpose: a bare Dict of matrices infers
+        # Dict{String,Vector{Vector{Float64}}}, and assigning a FLAT vector (a1/d/c) or a
+        # scalar into it then fails to convert before the parser is ever reached.
+        base = Dict{String,Any}("statespace" => Dict{String,Any}(
+            "Z" => [[1.0]], "H" => [[2.0]], "T" => [[1.0]], "Q" => [[3.0]]))
+        s = get_statespace(base)
+        @test s.n_obs == 1 && s.n_state == 1
+        @test s.Z == reshape([1.0], 1, 1) && s.Q == reshape([3.0], 1, 1)
+        @test s.init_mode == :kappa            # default
+        @test s.R === nothing && s.d === nothing && s.c === nothing
+        @test s.a1 === nothing && s.P1 === nothing
+
+        # Multivariate: Z is n_obs × n_state, so 2 series loading on 1 state
+        biv = Dict{String,Any}("statespace" => Dict{String,Any}(
+            "Z" => [[1.0], [0.7]], "H" => [[1.0, 0.0], [0.0, 2.0]],
+            "T" => [[0.95]], "Q" => [[0.5]], "d" => [0.0, 0.0], "c" => [0.0],
+            "init_mode" => "diffuse"))
+        b = get_statespace(biv)
+        @test b.n_obs == 2 && b.n_state == 1
+        @test b.init_mode == :diffuse
+        @test b.d == [0.0, 0.0] && b.c == [0.0]
+
+        # Explicit initialisation: a1 AND P1 together
+        ex = deepcopy(base)
+        ex["statespace"]["a1"] = [0.0]; ex["statespace"]["P1"] = [[10.0]]
+        e = get_statespace(ex)
+        @test e.a1 == [0.0] && e.P1 == reshape([10.0], 1, 1)
+
+        # Explicit R with r ≠ n_state
+        rr = Dict{String,Any}("statespace" => Dict{String,Any}(
+            "Z" => [[1.0, 0.0]], "H" => [[1.0]], "T" => [[1.0, 0.0], [0.0, 1.0]],
+            "Q" => [[1.0]], "R" => [[1.0], [0.0]]))
+        r = get_statespace(rr)
+        @test r.n_state == 2 && size(r.R) == (2, 1) && size(r.Q) == (1, 1)
+
+        _code(f) = try; f(); nothing; catch e; e isa CliError ? e.code : rethrow(); end
+        # missing section / missing required key
+        @test _code(() -> get_statespace(Dict())) == "config/missing"
+        @test _code(() -> get_statespace(Dict{String,Any}("statespace" => Dict{String,Any}("Z" => [[1.0]])))) == "config/missing-key"
+        # Dimensional consistency is checked HERE (config/shape, exit 4) rather than left to the
+        # MEMs constructor, so the error names the file the user wrote instead of surfacing as
+        # an untyped ArgumentError.
+        badH = deepcopy(base); badH["statespace"]["H"] = [[1.0, 0.0], [0.0, 1.0]]
+        @test _code(() -> get_statespace(badH)) == "config/shape"
+        badT = deepcopy(base); badT["statespace"]["T"] = [[1.0, 0.0], [0.0, 1.0]]
+        @test _code(() -> get_statespace(badT)) == "config/shape"
+        badd = deepcopy(base); badd["statespace"]["d"] = [0.0, 0.0]
+        @test _code(() -> get_statespace(badd)) == "config/shape"
+        badc = deepcopy(base); badc["statespace"]["c"] = [0.0, 0.0]
+        @test _code(() -> get_statespace(badc)) == "config/shape"
+        badR = deepcopy(base); badR["statespace"]["R"] = [[1.0, 0.0]]   # 1×2: Q must then be 2×2
+        @test _code(() -> get_statespace(badR)) == "config/shape"
+        # Q larger than the state with no explicit R — MEMs' default R = I(n_state, size(Q,1))
+        # would be malformed, so reject it here rather than let the constructor throw.
+        bigQ = deepcopy(base); bigQ["statespace"]["Q"] = [[1.0, 0.0], [0.0, 1.0]]
+        @test _code(() -> get_statespace(bigQ)) == "config/shape"
+        # a1 without P1 is SILENTLY IGNORED by MEMs (it switches to :explicit only when both are
+        # present), so a user supplying one would think it applied. Reject the half-specification.
+        half = deepcopy(base); half["statespace"]["a1"] = [0.0]
+        @test _code(() -> get_statespace(half)) == "config/shape"
+        halfP = deepcopy(base); halfP["statespace"]["P1"] = [[1.0]]
+        @test _code(() -> get_statespace(halfP)) == "config/shape"
+        wrongA1 = deepcopy(base); wrongA1["statespace"]["a1"] = [0.0, 0.0]
+        wrongA1["statespace"]["P1"] = [[1.0]]
+        @test _code(() -> get_statespace(wrongA1)) == "config/shape"
+        # bad init_mode / types
+        badmode = deepcopy(base); badmode["statespace"]["init_mode"] = "bogus"
+        @test _code(() -> get_statespace(badmode)) == "config/invalid"
+        @test get_statespace(deepcopy(base)).init_mode == :kappa
+        for m in ("kappa", "diffuse", "stationary")
+            ok = deepcopy(base); ok["statespace"]["init_mode"] = m
+            @test get_statespace(ok).init_mode == Symbol(m)
+        end
+        ragged = deepcopy(base); ragged["statespace"]["Z"] = [[1.0], [1.0, 2.0]]
+        @test _code(() -> get_statespace(ragged)) == "config/shape"
+        nonnum = deepcopy(base); nonnum["statespace"]["Z"] = [["a"]]
+        @test _code(() -> get_statespace(nonnum)) == "config/type"
+        notarr = deepcopy(base); notarr["statespace"]["Z"] = 3.0
+        @test _code(() -> get_statespace(notarr)) == "config/type"
+        badvec = deepcopy(base); badvec["statespace"]["d"] = "nope"
+        @test _code(() -> get_statespace(badvec)) == "config/type"
+    end
+
     @testset "_parse_matrix" begin
         # Valid 2x3 → correct Matrix{Float64}
         mat = _parse_matrix([[1, 2, 3], [4, 5, 6]])

--- a/test/test_commands.jl
+++ b/test/test_commands.jl
@@ -2431,6 +2431,16 @@ end  # Shared utilities
         _tbl_with(doc, cols...) = first(t for t in _tables(doc) if Set(String.(cols)) ⊆ Set(String.(t.columns)))
         _metrics(doc) = Set(String(collect(r)[1]) for r in
                             first(t for t in _tables(doc) if "metric" in String.(t.columns)).rows)
+        # Local on purpose: `_mval` in the MS testset is a testset-SCOPED closure, not a
+        # global, so reaching for it from here would be an UndefVarError at run time.
+        _mv(doc, name) = begin
+            kv = first(t for t in _tables(doc) if "metric" in String.(t.columns))
+            v = nothing
+            for r in kv.rows
+                rr = collect(r); String(rr[1]) == name && (v = rr[2])
+            end
+            v
+        end
         _eerr(args) = begin
             e = nothing
             try; _capture() do; _dispatch_via_app(vcat(String["estimate"], collect(String, args))); end; catch ex; e=ex; end
@@ -2463,6 +2473,67 @@ end  # Shared utilities
                 @test length(collect(pt.rows)) == 2               # σ²_ε, σ²_η
                 m = _metrics(doc)
                 @test Set(["model", "loglik", "converged", "n_state"]) ⊆ m
+            end
+
+            @testset "statespace --config — general fixed-matrix system (#71)" begin
+                # A general system is MULTIVARIATE and has NO estimated hyper-parameters, so it
+                # renders a SYSTEM table (matrix|role|rows|cols) instead of parameter|estimate —
+                # `theta`/`param_names` come back empty and the parameter table would otherwise
+                # be silently blank.
+                bi = joinpath(dir, "bi.csv")
+                open(bi, "w") do io
+                    println(io, "y1,y2")
+                    for t in 1:60
+                        f = 10.0 + 0.1*t
+                        println(io, "$(f + 0.1*sin(t)),$(0.7*f + 0.1*cos(t))")
+                    end
+                end
+                cfg = joinpath(dir, "ss.toml")
+                write(cfg, """
+                [statespace]
+                Z = [[1.0], [0.7]]
+                H = [[1.0, 0.0], [0.0, 2.0]]
+                T = [[0.95]]
+                Q = [[0.5]]
+                """)
+                doc = _edoc(["statespace", bi, "--config", cfg])
+                @test doc.status == "ok"
+                st = _tbl_with(doc, "matrix", "role", "rows", "cols")
+                rows = collect(st.rows)
+                @test Set(String(collect(r)[1]) for r in rows) == Set(["Z","H","T","Q","R","d","c"])
+                dims = Dict(String(collect(r)[1]) => (Int(collect(r)[3]), Int(collect(r)[4])) for r in rows)
+                @test dims["Z"] == (2, 1)          # n_obs × n_state
+                @test dims["H"] == (2, 2)
+                @test dims["T"] == (1, 1)
+                @test dims["R"] == (1, 1)          # defaulted to I by MEMs
+                m = _metrics(doc)
+                @test Set(["model", "loglik", "init_mode", "n_obs_series", "n_state",
+                           "n_periods", "method"]) ⊆ m
+                # a fixed-matrix system is filtered, never optimized
+                @test String(_mv(doc, "method")) == "filter"
+                @test String(_mv(doc, "model")) == "general"
+                @test Int(_mv(doc, "n_obs_series")) == 2
+                @test Int(_mv(doc, "n_state")) == 1
+                @test Int(_mv(doc, "n_periods")) == 60
+                # --config supersedes --model; the canned parameter table must NOT appear
+                @test isempty([t for t in _tables(doc) if "parameter" in String.(t.columns)])
+
+                # n_obs implied by Z must match the CSV's numeric column count → data/shape (3)
+                e = _eerr(["statespace", uni, "--config", cfg])
+                @test e isa CliError && e.code == "data/shape" && exit_class(e) == 3
+                # a malformed system is a CONFIG error (exit 4), naming the file the user wrote
+                badcfg = joinpath(dir, "bad.toml")
+                write(badcfg, """
+                [statespace]
+                Z = [[1.0]]
+                H = [[1.0, 0.0], [0.0, 1.0]]
+                T = [[1.0]]
+                Q = [[1.0]]
+                """)
+                eb = _eerr(["statespace", uni, "--config", badcfg])
+                @test eb isa CliError && exit_class(eb) == 4
+                # ...and the canned path is unaffected by all of this
+                @test _edoc(["statespace", uni, "--model", "local-level"]).status == "ok"
             end
 
             @testset "statespace local-linear-trend — 3 hyper-params" begin


### PR DESCRIPTION
Closes the remaining **#71** scope. **No new leaves** (361 unchanged) — this is an option on an existing leaf. Config-parser tests 186 → 207.

Scope asked for *"config-TOML for general matrices"*; only the two canned systems (local level, local linear trend) were wired. Upstream supports the general case directly, so the gap was entirely ours.

## What it does

New `get_statespace(config)` parses a `[statespace]` section into the standard single-block form

```
yₜ   = Z αₜ + d + εₜ,     εₜ ~ N(0, H)
αₜ₊₁ = T αₜ + c + R ηₜ,   ηₜ ~ N(0, Q)
```

then builds `StateSpaceModel(Z, H, T, Q; …)` and filters it with `estimate_statespace(ss, y)`.

```toml
[statespace]
Z = [[1.0], [0.7]]              # n_obs × n_state    (required)
H = [[1.0, 0.0], [0.0, 2.0]]    # n_obs × n_obs      (required)
T = [[0.95]]                    # n_state × n_state  (required)
Q = [[0.5]]                     # r × r              (required)
d = [0.0, 0.0]                  # optional, default 0
c = [0.0]                       # optional, default 0
R = [[1.0]]                     # optional, default I
a1 = [0.0]                      # optional, with P1
P1 = [[10.0]]                   # optional, with a1
init_mode = "kappa"             # kappa | diffuse | stationary
```

**Three names for one matrix, unavoidably:** the TOML key is `T`, the constructor keyword is `T_mat`, the struct field is `Tt` — `T` is the Julia type parameter.

## Error classes

The general path is **multivariate** (`Z` is `n_obs × n_state`), so it loads the whole numeric matrix via the hardened `load_multivariate_data` rather than the canned path's single `--column`.

- A mismatch between `Z`'s implied `n_obs` and the CSV's column count → **`data/shape` (3)**, a property of the data.
- Every dimensional inconsistency *within* the config → **`config/shape` (4)**, caught in the parser and naming the file the user wrote, rather than reaching MEMs as an untyped `ArgumentError`.

Two guards worth calling out:

- **`a1` and `P1` must be supplied together or not at all.** Upstream switches to `init_mode=:explicit` only when *both* are present, so a lone `a1` would be silently ignored and the user would believe it applied. Rejected instead.
- **`Q` larger than the state with no explicit `R` is rejected** — MEMs' default `R = I(n_state, size(Q,1))` would be malformed.

## Rendering

A fixed-matrix system has **no estimated hyper-parameters**. `estimate_statespace(ss, y)` returns `method = :filter` with `theta` and `param_names` **empty**, so the existing parameter table would render blank and read like a failed fit. The general path emits a **system table** (`matrix|role|rows|cols`) instead, reporting the matrices in force *after* upstream applies its defaults (`R = I`, `d = c = 0`) — the part users most often get wrong.

## T3 asserts an equivalence, not a shape

Writing the local level out by hand with the variances the canned MLE found reproduces the canned log-likelihood **exactly** — verified live, `-318.4869541285637` both ways. A transposed `Z`/`T` or crossed `H`/`Q` would break that; a shape test would not notice.

## Mock

Gained the system fields, the fixed-matrix outer constructor (mirroring real's validation *and* its defaults), and `estimate_statespace(ss, y)` returning empty `theta` with `method = :filter` exactly as real does — **a mock that populated `theta` here would hide the empty-parameter-table case the CLI has to render around.**

**Test-fixture gotcha:** a bare `Dict("statespace" => Dict("Z" => [[1.0]], …))` infers `Dict{String,Vector{Vector{Float64}}}`, so assigning a flat vector (`a1`/`d`/`c`) or a scalar into it fails to convert *before the parser is ever reached*. Fixtures are `Dict{String,Any}`.

## Gates

| Gate | Result |
|---|---|
| T1/T2 | **1655/1655** (config 207/207), exit 0 |
| T3 (real MEMs) | **2112/2112**, exit 0 |
| `check_mock_surface.jl` | PASS |
| `generate_cli_reference.jl --check` | OK (361 leaves) |
| gitleaks | no leaks (409 commits) |
| semgrep | 0 findings |

Docs: new **General systems: `--config`** subsection in `docs/src/commands/estimate.md` with the full schema, plus the regenerated reference.