### PR TITLE
ci: fix Windows nightly (USERPROFILE tilde) + serialize gh-pages deploys

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -8,9 +8,14 @@ on:
     branches: [master, dev]
   workflow_dispatch:
 
+# master pushes deploy the dev docs and tag pushes deploy the version dirs — at
+# release time both fire on the same commit and race on the gh-pages push (the
+# loser dies with "! [rejected] ... fetch first", which is how the v0.9.2 master
+# run failed). Deploying refs share ONE queued group; PR/dev builds keep per-ref
+# cancellation.
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: docs-${{ (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))) && 'deploy' || github.ref }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))) }}
 
 jobs:
   docs:

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -4795,7 +4795,9 @@ col_index(tbl, name::AbstractString) = findfirst(==(name), table_cols(tbl))
         @testset "~ is expanded by the loader (the REPL has no shell)" begin
             mktempdir() do dir
                 CSV.write(joinpath(dir, "tilde.csv"), DataFrame(a=randn(20)))
-                withenv("HOME" => dir) do
+                # expanduser goes through libuv's uv_os_homedir: HOME on Unix,
+                # USERPROFILE on Windows — set both or the Windows nightly fails.
+                withenv("HOME" => dir, "USERPROFILE" => dir) do
                     @test nrow(Friedman.load_data("~/tilde.csv")) == 20
                 end
             end


### PR DESCRIPTION
Two CI-only fixes to restore green on the master tip before the v0.10.0 program starts:

1. **Windows nightly red since the v0.9.2 merge (3 consecutive failures, both pinned and mems-dev cells):** the `~ is expanded by the loader` T3 test set only `HOME`, but `expanduser` goes through libuv's `uv_os_homedir`, which reads `USERPROFILE` on Windows — the tilde resolved to the real profile, the file was missing, and the test errored. Both env vars are now set. (The T3 CI job is ubuntu-only, so the 3-OS nightly was the first tier that could see it — the recurring class.)

2. **Documentation deploy race at release time:** per-ref concurrency let the master push (deploys dev docs) and the tag push (deploys the version dir) race on `git push gh-pages`; the master run lost with `! [rejected] … fetch first` at v0.9.2. Deploying refs now share one queued concurrency group; PR/dev builds keep per-ref cancellation. (The failed master deploy was also re-run manually and is green — dev docs are current.)

No src/ changes; no output changes.